### PR TITLE
Adding HSC guide stars and modified filtering for AG

### DIFF
--- a/python/agActor/autoguide.py
+++ b/python/agActor/autoguide.py
@@ -59,9 +59,9 @@ def set_design_agc(*, frame_id=None, obswl=0.62, logger=None, **kwargs):
         logger and logger.info('design_id={},design_path={}'.format(design_id, design_path))
         if design_path is not None:
             taken_at = kwargs.get('taken_at')
-            magnitude = kwargs.get('magnitude', 20.0)
-            logger and logger.info('taken_at={},magnitude={}'.format(taken_at, magnitude))
-            guide_objects, *_ = pfs_design(design_id, design_path, logger=logger).guide_objects(magnitude=magnitude, obstime=taken_at)
+
+            logger and logger.info('taken_at={}'.format(taken_at))
+            guide_objects, *_ = pfs_design(design_id, design_path, logger=logger).guide_objects(obstime=taken_at)
         elif design_id is not None:
             guide_objects = opdb.query_pfs_design_agc(design_id)
         else:
@@ -71,13 +71,12 @@ def set_design_agc(*, frame_id=None, obswl=0.62, logger=None, **kwargs):
             inr = kwargs.get('inr')
             adc = kwargs.get('adc')
             m2_pos3 = kwargs.get('m2_pos3', 6.0)
-            magnitude = kwargs.get('magnitude', 20.0)
-            logger and logger.info('taken_at={},inr={},adc={},m2_pos3={},magnitude={}'.format(taken_at, inr, adc, m2_pos3, magnitude))
+            logger and logger.info('taken_at={},inr={},adc={},m2_pos3={}'.format(taken_at, inr, adc, m2_pos3))
             if 'dra' in kwargs: ra += kwargs.get('dra') / 3600
             if 'ddec' in kwargs: dec += kwargs.get('ddec') / 3600
             if 'dinr' in kwargs: inr += kwargs.get('dinr') / 3600
             logger and logger.info('ra={},dec={},inr={}'.format(ra, dec, inr))
-            guide_objects, *_ = gaia.get_objects(ra=ra, dec=dec, obstime=taken_at, inst_pa=inst_pa, adc=adc, m2pos3=m2_pos3, obswl=obswl, magnitude=magnitude)
+            guide_objects, *_ = gaia.get_objects(ra=ra, dec=dec, obstime=taken_at, inst_pa=inst_pa, adc=adc, m2pos3=m2_pos3, obswl=obswl)
     #logger and logger.info('guide_objects={}'.format(guide_objects))
     Field.guide_objects = guide_objects
 
@@ -116,7 +115,6 @@ if __name__ == '__main__':
     parser.add_argument('--center', default=None, help='field center coordinates ra, dec[, pa] (deg)')
     parser.add_argument('--offset', default=None, help='field offset coordinates dra, ddec[, dpa[, dinr]] (arcsec)')
     parser.add_argument('--dinr', type=float, default=None, help='instrument rotator offset, east of north (arcsec)')
-    parser.add_argument('--magnitude', type=float, default=None, help='magnitude limit')
     parser.add_argument('--fit-dinr', action=argparse.BooleanOptionalAction, default=argparse.SUPPRESS, help='')
     parser.add_argument('--fit-dscale', action=argparse.BooleanOptionalAction, default=argparse.SUPPRESS, help='')
     parser.add_argument('--max-ellipticity', type=float, default=argparse.SUPPRESS, help='')
@@ -134,8 +132,6 @@ if __name__ == '__main__':
         kwargs['offset'] = tuple([float(x) for x in args.offset.split(',')])
     if args.dinr is not None:
         kwargs['dinr'] = args.dinr
-    if args.magnitude is not None:
-        kwargs['magnitude'] = args.magnitude
     kwargs |= {key: getattr(args, key) for key in field_acquisition._KEYMAP if key in args}
     print('kwargs={}'.format(kwargs))
 

--- a/python/agActor/data_utils.py
+++ b/python/agActor/data_utils.py
@@ -36,7 +36,7 @@ def write_agc_match(*, design_id, frame_id, guide_objects, detected_objects, ide
                 guide_objects['source_id'][x[1]],
                 x[4], - x[5],  # hsc -> pfs focal plane coordinate system
                 x[2], - x[3],  # hsc -> pfs focal plane coordinate system
-                0  # flags
+                guide_objects['filter_flag'][x[1]]  # flags
             )
             for x in identified_objects
         ],

--- a/python/agActor/opdb.py
+++ b/python/agActor/opdb.py
@@ -64,7 +64,7 @@ class opDB:
         #     (pfs_design_id,)
         # )
         return opDB.fetchall(
-            'SELECT guide_star_id,guide_star_ra,guide_star_dec,guide_star_magnitude,agc_camera_id,agc_target_x_pix,agc_target_y_pix FROM pfs_design_agc WHERE pfs_design_id=%s ORDER BY guide_star_id',
+            'SELECT guide_star_id,guide_star_ra,guide_star_dec,guide_star_magnitude,agc_camera_id,agc_target_x_pix,agc_target_y_pix,guide_star_flag FROM pfs_design_agc WHERE pfs_design_id=%s ORDER BY guide_star_id',
             (pfs_design_id,)
         )
 


### PR DESCRIPTION
* Remove magnitude from the `guide_objects` coming from the pfsDesign.
* Remove magnitude from the `guide_objects` coming from the gaia database lookup.
* Remove magnitude variable from kwargs going into the various `get_objects`.
* Remove remaining references to magnitude limits.
* Add the expected guide objects position in both pixels and detector plane.
* Quick fix to the det2dp call.
* Adding the filterFlag for saving.
* Get flag from db and pfs_design
* Write out the filter flags.
* Write empty flags if we don't apply filtering.

This branch was tested during the night of 2025-05-20.

Replaces #4 