### PR TITLE
Old design files not being read by agActor - tickets/INSTRM-2551

### DIFF
--- a/python/agActor/pfs_design.py
+++ b/python/agActor/pfs_design.py
@@ -65,9 +65,15 @@ class pfsDesign:
         _icrs_d = _icrs.apply_space_motion(new_obstime=_obstime)  # of date
         _guide_objects['ra'] = _icrs_d.ra.deg
         _guide_objects['dec'] = _icrs_d.dec.deg
-        #guide_objects = tuple(map(tuple, _guide_objects[['objId', 'ra', 'dec', 'magnitude', 'agId', 'agX', 'agY']]))
-        guide_objects = _guide_objects[['objId', 'ra', 'dec', 'magnitude', 'agId', 'agX', 'agY', 'flag']]
-        #guide_objects.dtype.names = ('source_id', 'ra', 'dec', 'mag', 'camera_id', 'x', 'y')
+
+        cols = ['objId', 'ra', 'dec', 'magnitude', 'agId', 'agX', 'agY']
+
+        # Check if 'flag' column exists and if so, add it to cols.
+        if 'flag' in _guide_objects.dtype.names:
+            cols.append('flag')
+
+        guide_objects = _guide_objects[cols]
+
         return guide_objects, ra, dec, inst_pa
 
     @staticmethod


### PR DESCRIPTION
* When reading the `guidestars` table from a pfsDesign, check if the `flag` column exists before trying to copy.
* If the `flag` column then exists, use it to apply filtering during the `_acquire_field` sequence..
* If the `flag` column doesn't exist, add 0 entries.