### PR TITLE
Make all updateTelStatus calls uniform, along with agc expose timelim

### DIFF
--- a/python/agActor/actorCalls.py
+++ b/python/agActor/actorCalls.py
@@ -1,0 +1,30 @@
+def updateTelStatus(actor, logger, visit_id=None):
+    """Fetch the current tel_status.
+
+    Parameters
+    ----------
+    actor : `actorcore.Actor`
+       where to send commands and fetch results from.
+    logger : `logging.Logger`
+    visit_id : int, optional
+       if we know it, the visit to associate status with
+
+    Returns
+    -------
+    tel_status : the gen2.tel_status keyword value
+    """
+
+    # Note that visit_id can be 0 when the ag is testing or doing OTF
+    if visit_id:
+        visitStr = 'visit={}'.format(visit_id)
+    else:
+        visitStr = ''
+    actor.queueCommand(
+        actor='gen2',
+        cmdStr='updateTelStatus caller={} {}'.format(actor.name,
+                                                     visitStr),
+        timeLim=5
+    ).get()
+    tel_status = actor.gen2.tel_status
+
+    return tel_status


### PR DESCRIPTION
Was intending to also pull the agcc.expose call out, but that has a bit more context so I didn't.

This ticket actually comes with INSTRM-2555 and INSTRM-2553.