### PR TITLE
Only use good guide stars - tickets/INSTRM-2599

### DIFF
--- a/python/agActor/field_acquisition.py
+++ b/python/agActor/field_acquisition.py
@@ -56,10 +56,28 @@ class AutoGuiderStarMask(IntFlag):
     NON_BINARY = 0x00400
     PHOTO_SIG = 0x00800
     GALAXY = 0x01000
-    MAX_ELLIPTICITY = 0x02000
-    MAX_SIZE = 0x04000
-    MIN_SIZE = 0x08000
-    MAX_RESID = 0x10000
+
+
+# The stars we want to use for initial acquisition.
+GOOD_ACQUISITION_MASK = (
+    AutoGuiderStarMask.GAIA |
+    AutoGuiderStarMask.PMRA |
+    AutoGuiderStarMask.PMRA_SIG |
+    AutoGuiderStarMask.PMDEC |
+    AutoGuiderStarMask.PMDEC_SIG |
+    AutoGuiderStarMask.PARA |
+    AutoGuiderStarMask.PARA_SIG |
+    AutoGuiderStarMask.ASTROMETRIC |
+    AutoGuiderStarMask.NON_BINARY |
+    AutoGuiderStarMask.PHOTO_SIG
+)
+
+# The stars we want to use for autoguiding. This is not yet being used.
+GOOD_GUIDING_MASK = (
+    AutoGuiderStarMask.GAIA |
+    AutoGuiderStarMask.HSC |
+    AutoGuiderStarMask.NON_BINARY
+)
 
 
 def _filter_kwargs(kwargs):
@@ -182,7 +200,11 @@ def _acquire_field(guide_objects, detected_objects, ra, dec, taken_at, adc, inst
         b = numpy.sqrt(p - q)
         return a, b
 
-    _guide_objects = numpy.array([(x[1], x[2], x[3]) for x in guide_objects])
+    # This is not being passed from anywhere yet, so this is a placeholder.
+    GUIDE_MASK = kwargs.get('GUIDE_MASK', GOOD_ACQUISITION_MASK)
+
+    _guide_objects = numpy.array([(x[1], x[2], x[3]) for x in guide_objects if int(x[-2]) == GUIDE_MASK])
+    logger and logger.info(f'Found {len(_guide_objects)} guide objects with AutoGuideStarMask({GUIDE_MASK}) {AutoGuiderStarMask(GUIDE_MASK).name}')
 
     _detected_objects = numpy.array(
         [


### PR DESCRIPTION
Change the filtering to only use our GOOD_GUIDE_STAR_MASK for computing the offsets. This should eventually be updated to have slightly different filters for initial acquisition vs guiding, but this is a better default than including everything.

```
GOOD_GUIDE_STAR_MASK = (
    AutoGuiderStarMask.GAIA |
    AutoGuiderStarMask.PMRA |
    AutoGuiderStarMask.PMRA_SIG |
    AutoGuiderStarMask.PMDEC |
    AutoGuiderStarMask.PMDEC_SIG |
    AutoGuiderStarMask.PARA |
    AutoGuiderStarMask.PARA_SIG |
    AutoGuiderStarMask.ASTROMETRIC |
    AutoGuiderStarMask.NON_BINARY |
    AutoGuiderStarMask.PHOTO_SIG
)
```