### PR TITLE
Update IERS methods for agActor - tickets/INSTRM-1057

### DIFF
--- a/python/agActor/_gen2_gaia.py
+++ b/python/agActor/_gen2_gaia.py
@@ -2,16 +2,12 @@ from datetime import datetime, timezone
 from numbers import Number
 import numpy
 from astropy import units
-from astropy.coordinates import AltAz, Angle, Distance, SkyCoord, solar_system_ephemeris
+from astropy.coordinates import AltAz, Angle, Distance, SkyCoord
 from astropy.time import Time
-from astropy.utils import iers
 from pfs.utils.coordinates import coordinates
 
 from pfs.utils.coordinates import Subaru_POPT2_PFS
 
-
-iers.conf.auto_download = True
-solar_system_ephemeris.set('de440')
 
 _popt2 = Subaru_POPT2_PFS.POPT2()
 _pfs = Subaru_POPT2_PFS.PFS()

--- a/python/agActor/_gen2_gaia_annulus.py
+++ b/python/agActor/_gen2_gaia_annulus.py
@@ -2,15 +2,11 @@ from datetime import datetime, timezone
 from numbers import Number
 import numpy
 from astropy import units
-from astropy.coordinates import AltAz, Angle, Distance, SkyCoord, solar_system_ephemeris
+from astropy.coordinates import AltAz, Angle, Distance, SkyCoord
 from astropy.time import Time
-from astropy.utils import iers
 from pfs.utils.coordinates import coordinates
 from pfs.utils.coordinates import Subaru_POPT2_PFS
 
-
-iers.conf.auto_download = True
-solar_system_ephemeris.set('de440')
 
 _popt2 = Subaru_POPT2_PFS.POPT2()
 _pfs = Subaru_POPT2_PFS.PFS()

--- a/python/agActor/astrometry.py
+++ b/python/agActor/astrometry.py
@@ -3,15 +3,11 @@ import itertools
 from numbers import Number
 import numpy
 from astropy import units
-from astropy.coordinates import AltAz, Angle, SkyCoord, solar_system_ephemeris
+from astropy.coordinates import AltAz, Angle, SkyCoord
 from astropy.time import Time
-from astropy.utils import iers
 from pfs.utils.coordinates import coordinates
 from pfs.utils.coordinates import Subaru_POPT2_PFS
 
-
-iers.conf.auto_download = True
-solar_system_ephemeris.set('de440')
 
 _subaru = Subaru_POPT2_PFS.Subaru()
 popt2 = Subaru_POPT2_PFS.POPT2()

--- a/python/agActor/kawanomoto/Subaru_POPT2_PFS_AG.py
+++ b/python/agActor/kawanomoto/Subaru_POPT2_PFS_AG.py
@@ -6,9 +6,6 @@ import astropy.units as au
 import astropy.time as at
 import astropy.coordinates as ac
 
-from astropy.utils import iers
-iers.conf.auto_download = False
-
 from pfs.utils.coordinates import Subaru_POPT2_PFS as pfs
 
 ### ccd pixel size

--- a/python/agActor/main.py
+++ b/python/agActor/main.py
@@ -6,6 +6,7 @@ from actorcore.ICC import ICC
 from agActor.agcc import Agcc
 from agActor.mlp1 import Mlp1
 from agActor.gen2 import Gen2
+from ics.utils import pfsIERS
 
 
 class AgActor(ICC):

--- a/python/agActor/pfs_design.py
+++ b/python/agActor/pfs_design.py
@@ -2,15 +2,10 @@ from datetime import datetime, timezone
 from numbers import Number
 import os
 from astropy import units
-from astropy.coordinates import Angle, Distance, SkyCoord, solar_system_ephemeris
+from astropy.coordinates import Angle, Distance, SkyCoord
 from astropy.time import Time
-from astropy.utils import iers
 import fitsio
 import numpy
-
-
-iers.conf.auto_download = True
-solar_system_ephemeris.set('de440')
 
 
 class pfsDesign:

--- a/python/agActor/to_altaz.py
+++ b/python/agActor/to_altaz.py
@@ -1,13 +1,8 @@
 from datetime import datetime, timezone
 from numbers import Number
 from astropy import units
-from astropy.coordinates import AltAz, Angle, SkyCoord, solar_system_ephemeris
+from astropy.coordinates import AltAz, Angle, SkyCoord
 from astropy.time import Time
-from astropy.utils import iers
-
-
-iers.conf.auto_download = True
-solar_system_ephemeris.set('de440')
 
 
 def to_altaz(

--- a/ups/ics_agActor.table
+++ b/ups/ics_agActor.table
@@ -1,4 +1,5 @@
 setupRequired(ics_actorkeys)
+setupRequired(ics_utils)
 setupRequired(pfs_instdata)
 setupRequired(pfs_utils)
 


### PR DESCRIPTION
I've removed specific calls to anything related to IERS.

Note that the agActor has been using the `de440` JPL files and this would change that to be consistent with what we are using everywhere else.

I didn't know if we needed `ics_utils` in the UPS table explicitly.