### PR TITLE
Clean up repo - logging - tickets/INSTRM-2469-12

### DIFF
--- a/python/agActor/autoguide.py
+++ b/python/agActor/autoguide.py
@@ -1,7 +1,8 @@
-from agActor.catalog import gen2_gaia as gaia, astrometry
 from agActor import field_acquisition
-from agActor.utils.opdb import opDB as opdb
+from agActor.catalog import astrometry, gen2_gaia as gaia
 from agActor.catalog.pfs_design import pfsDesign as pfs_design
+from agActor.utils.logging import log_message
+from agActor.utils.opdb import opDB as opdb
 
 
 class Field:
@@ -16,51 +17,51 @@ def set_design(*, logger=None, **kwargs):
     field_acquisition.parse_kwargs(kwargs)
     design_id = kwargs.get("design_id")
     design_path = kwargs.get("design_path")
-    logger and logger.info(f"{design_id=},{design_path=}")
+    log_message(logger, f"{design_id=},{design_path=}")
     ra = kwargs.get("ra")
     dec = kwargs.get("dec")
     inst_pa = kwargs.get("inst_pa")
     if any(x is None for x in (ra, dec, inst_pa)):
         if any(x is not None for x in (design_id, design_path)):
             if design_path is not None:
-                logger and logger.info(f"Setting psf_design via {design_path=}")
+                log_message(logger, f"Setting psf_design via {design_path=}")
                 _ra, _dec, _inst_pa = pfs_design(design_id, design_path, logger=logger).center
-                logger and logger.info(f"ra={_ra},dec={_dec},inst_pa={_inst_pa}")
+                log_message(logger, f"ra={_ra},dec={_dec},inst_pa={_inst_pa}")
             else:
-                logger and logger.info(f"Setting psf_design via {design_id=}")
+                log_message(logger, f"Setting psf_design via {design_id=}")
                 _, _ra, _dec, _inst_pa, *_ = opdb.query_pfs_design(design_id)
-                logger and logger.info(f"ra={_ra},dec={_dec},inst_pa={_inst_pa}")
+                log_message(logger, f"ra={_ra},dec={_dec},inst_pa={_inst_pa}")
             if ra is None:
                 ra = _ra
             if dec is None:
                 dec = _dec
             if inst_pa is None:
                 inst_pa = _inst_pa
-    logger and logger.info(f"ra={ra},dec={dec},inst_pa={inst_pa}")
-    logger and logger.info(f"Setting Field.design to {design_id=},{design_path=}")
+    log_message(logger, f"ra={ra},dec={dec},inst_pa={inst_pa}")
+    log_message(logger, f"Setting Field.design to {design_id=},{design_path=}")
     Field.design = design_id, design_path
-    logger and logger.info(f"Setting Field.center to {ra=},{dec=},{inst_pa=}")
+    log_message(logger, f"Setting Field.center to {ra=},{dec=},{inst_pa=}")
     Field.center = ra, dec, inst_pa
-    logger and logger.info(f"Setting Field.guide_objects to []")
+    log_message(logger, f"Setting Field.guide_objects to empty list []")
     Field.guide_objects = []  # delay loading of guide objects
 
 
 def set_design_agc(*, frame_id=None, obswl=0.62, logger=None, **kwargs):
 
-    logger and logger.info(f"frame_id={frame_id}")
+    log_message(logger, f"frame_id={frame_id}")
     field_acquisition.parse_kwargs(kwargs)
     if frame_id is not None:
-        logger and logger.info(f"Setting pfs_design_agc via frame_id={frame_id}")
+        log_message(logger, f"Setting pfs_design_agc via frame_id={frame_id}")
         # generate guide objects from frame
         ra, dec, inst_pa = Field.center
-        logger and logger.info(f"ra={ra},dec={dec},inst_pa={inst_pa}")
+        log_message(logger, f"ra={ra},dec={dec},inst_pa={inst_pa}")
         taken_at, inr, adc, m2_pos3 = field_acquisition.get_tel_status(
             frame_id=frame_id, logger=logger, **kwargs
         )
-        logger and logger.info(f"taken_at={taken_at},inr={inr},adc={adc},m2_pos3={m2_pos3}")
-        logger and logger.info("Getting agc_data from oped for frame_id={}".format(frame_id))
+        log_message(logger, f"taken_at={taken_at},inr={inr},adc={adc},m2_pos3={m2_pos3}")
+        log_message(logger, f"Getting agc_data from opdb for frame_id={frame_id}")
         detected_objects = opdb.query_agc_data(frame_id)
-        logger and logger.info(f"Got {len(detected_objects)=} detected objects)")
+        log_message(logger, f"Got {len(detected_objects)=} detected objects")
 
         if "dra" in kwargs:
             ra += kwargs.get("dra") / 3600
@@ -68,8 +69,8 @@ def set_design_agc(*, frame_id=None, obswl=0.62, logger=None, **kwargs):
             dec += kwargs.get("ddec") / 3600
         if "dinr" in kwargs:
             inr += kwargs.get("dinr") / 3600
-        logger and logger.info("ra={},dec={},inr={}".format(ra, dec, inr))
-        logger and logger.info("Getting guide objects from astrometry")
+        log_message(logger, f"ra={ra},dec={dec},inr={inr}")
+        log_message(logger, "Getting guide objects from astrometry")
         guide_objects = astrometry.measure(
             detected_objects=detected_objects,
             ra=ra,
@@ -81,64 +82,62 @@ def set_design_agc(*, frame_id=None, obswl=0.62, logger=None, **kwargs):
             obswl=obswl,
             logger=logger,
         )
-        logger and logger.info(f"Got {len(guide_objects)=} guide objects)")
+        log_message(logger, f"Got {len(guide_objects)=} guide objects")
     else:
         # use guide objects from pfs design file or operational database, or generate on-the-fly
         design_id, design_path = Field.design
-        logger and logger.info("design_id={},design_path={}".format(design_id, design_path))
+        log_message(logger, f"design_id={design_id},design_path={design_path}")
         if design_path is not None:
-            logger and logger.info("Getting guide_objects via {}".format(design_path))
+            log_message(logger, f"Getting guide_objects via {design_path}")
             taken_at = kwargs.get("taken_at")
 
-            logger and logger.info("taken_at={}".format(taken_at))
+            log_message(logger, f"taken_at={taken_at}")
             guide_objects, *_ = pfs_design(design_id, design_path, logger=logger).guide_objects(
                 obstime=taken_at
             )
         elif design_id is not None:
-            logger and logger.info("Getting guide_objects from opdb via {}".format(design_id))
+            log_message(logger, f"Getting guide_objects from opdb via {design_id}")
             guide_objects = opdb.query_pfs_design_agc(design_id)
         else:
             ra, dec, inst_pa = Field.center
-            logger and logger.info("ra={},dec={},inst_pa={}".format(ra, dec, inst_pa))
+            log_message(logger, f"ra={ra},dec={dec},inst_pa={inst_pa}")
             taken_at = kwargs.get("taken_at")
             inr = kwargs.get("inr")
             adc = kwargs.get("adc")
             m2_pos3 = kwargs.get("m2_pos3", 6.0)
-            logger and logger.info("taken_at={},inr={},adc={},m2_pos3={}".format(taken_at, inr, adc, m2_pos3))
+            log_message(logger, f"taken_at={taken_at},inr={inr},adc={adc},m2_pos3={m2_pos3}")
             if "dra" in kwargs:
                 ra += kwargs.get("dra") / 3600
             if "ddec" in kwargs:
                 dec += kwargs.get("ddec") / 3600
             if "dinr" in kwargs:
                 inr += kwargs.get("dinr") / 3600
-            logger and logger.info("ra={},dec={},inr={}".format(ra, dec, inr))
-            logger and logger.info("Getting guide objects from gaia database")
+            log_message(logger, f"ra={ra},dec={dec},inr={inr}")
+            log_message(logger, "Getting guide objects from gaia database")
             guide_objects, *_ = gaia.get_objects(
                 ra=ra, dec=dec, obstime=taken_at, inst_pa=inst_pa, adc=adc, m2pos3=m2_pos3, obswl=obswl
             )
 
-    logger and logger.info(f"Got {len(guide_objects)} guide objects before filtering.")
+    log_message(logger, f"Got {len(guide_objects)} guide objects before filtering.")
     guide_objects = field_acquisition.filter_guide_objects(guide_objects, logger)
 
-    logger and logger.info("Setting Field.guide_objects to")
+    log_message(logger, "Setting Field.guide_objects to")
     Field.guide_objects = guide_objects
 
 
 def autoguide(*, frame_id, obswl=0.62, logger=None, **kwargs):
 
-    logger and logger.info("Calling autoguide.autoguide with frame_id={}".format(frame_id))
+    log_message(logger, f"Calling autoguide.autoguide with frame_id={frame_id}")
     field_acquisition.parse_kwargs(kwargs)
     guide_objects = Field.guide_objects
 
     ra, dec, inst_pa = Field.center
-    logger and logger.info("ra={},dec={}".format(ra, dec))
-    logger and logger.info("Getting telescope status")
-    taken_at, inr, adc, m2_pos3 = field_acquisition.get_tel_status(
-        frame_id=frame_id, logger=logger, **kwargs
-    )
-    logger and logger.info("Getting agc_data for frame_id={}".format(frame_id))
+    log_message(logger, f"ra={ra},dec={dec}")
+    log_message(logger, "Getting telescope status")
+    taken_at, inr, adc, m2_pos3 = field_acquisition.get_tel_status(frame_id=frame_id, logger=logger, **kwargs)
+    log_message(logger, f"Getting agc_data for frame_id={frame_id}")
     detected_objects = opdb.query_agc_data(frame_id)
-    logger and logger.info(f"Got {len(detected_objects)=} detected objects)")
+    log_message(logger, f"Got {len(detected_objects)=} detected objects")
     if "dra" in kwargs:
         ra += kwargs.get("dra") / 3600
     if "ddec" in kwargs:
@@ -147,10 +146,10 @@ def autoguide(*, frame_id, obswl=0.62, logger=None, **kwargs):
         inst_pa += kwargs.get("dpa") / 3600
     if "dinr" in kwargs:
         inr += kwargs.get("dinr") / 3600
-    logger and logger.info("ra={},dec={},inst_pa={},inr={}".format(ra, dec, inst_pa, inr))
+    log_message(logger, f"ra={ra},dec={dec},inst_pa={inst_pa},inr={inr}")
     _kwargs = field_acquisition.filter_kwargs(kwargs)
-    logger and logger.info("_kwargs={}".format(_kwargs))
-    logger and logger.info("Calling field_acquisition._acquire_field from autoguide.autoguide")
+    log_message(logger, f"_kwargs={_kwargs}")
+    log_message(logger, "Calling field_acquisition.calculate_guide_offsets from autoguide.autoguide")
     return (
         ra,
         dec,

--- a/python/agActor/catalog/astrometry.py
+++ b/python/agActor/catalog/astrometry.py
@@ -9,6 +9,8 @@ from astropy.time import Time
 from astropy.utils import iers
 from pfs.utils.coordinates import Subaru_POPT2_PFS, coordinates
 
+from agActor.utils.logging import log_message
+
 iers.conf.auto_download = True
 solar_system_ephemeris.set("de440")
 
@@ -33,10 +35,10 @@ def measure(
     logger=None,
 ):
 
-    logger and logger.info(
-        "ra={},dec={},obstime={},inst_pa={},inr={},adc={},m2_pos3={},temperature={},relative_humidity={},pressure={},obswl={}".format(
-            ra, dec, obstime, inst_pa, inr, adc, m2_pos3, temperature, relative_humidity, pressure, obswl
-        )
+    log_message(
+        logger,
+        f"{ra=},{dec=},{obstime=},{inst_pa=},{inr=},{adc=},"
+        f"{m2_pos3=},{temperature=},{relative_humidity=},{pressure=},{obswl=}",
     )
 
     ra = Angle(ra, unit=u.deg)
@@ -71,9 +73,7 @@ def measure(
         altaz_p = icrs_p.transform_to(frame_tc)
         parallactic_angle = altaz_c.position_angle(altaz_p).to(u.deg).value
         inr = (parallactic_angle + inst_pa + 180) % 360 - 180
-        logger and logger.info(
-            "parallactic_angle={},inst_pa={},inr={}".format(parallactic_angle, inst_pa, inr)
-        )
+        log_message(logger, f"parallactic_angle={parallactic_angle},inst_pa={inst_pa},inr={inr}")
 
     # detected stellar objects in the equatorial coordinates
     icam, x_det, y_det, flags = np.array(detected_objects)[:, (0, 3, 4, -1)].T

--- a/python/agActor/catalog/pfs_design.py
+++ b/python/agActor/catalog/pfs_design.py
@@ -9,6 +9,8 @@ from astropy.coordinates import Angle, Distance, SkyCoord, solar_system_ephemeri
 from astropy.time import Time
 from astropy.utils import iers
 
+from agActor.utils.logging import log_message
+
 iers.conf.auto_download = True
 solar_system_ephemeris.set("de440")
 
@@ -21,16 +23,12 @@ class pfsDesign:
             if design_path is None:
                 raise TypeError('__init__() missing argument(s): "design_id" and/or "design_path"')
             elif not os.path.isfile(design_path):
-                raise ValueError(
-                    '__init__() "design_path" not an existing regular file: "{}"'.format(design_path)
-                )
+                raise ValueError(f'__init__() "design_path" not an existing regular file: "{design_path}"')
         else:
             if design_path is None:
                 design_path = "/data/pfsDesign"
             elif not os.path.isdir(design_path):
-                raise ValueError(
-                    '__init__() "design_path" not an existing directory: "{}"'.format(design_path)
-                )
+                raise ValueError(f'__init__() "design_path" not an existing directory: "{design_path}"')
             design_path = self.to_design_path(design_id, design_path)
         self.design_path = design_path
         self.logger = logger
@@ -56,7 +54,7 @@ class pfsDesign:
                 else Time(obstime) if obstime is not None else Time.now()
             )
         )
-        self.logger and self.logger.info("obstime={},_obstime={}".format(obstime, _obstime))
+        log_message(self.logger, f"obstime={obstime},_obstime={_obstime}")
         with fitsio.FITS(self.design_path) as fits:
             header = fits[0].read_header()
             ra = header["RA"]
@@ -97,4 +95,4 @@ class pfsDesign:
     @staticmethod
     def to_design_path(design_id, design_path=""):
 
-        return os.path.join(design_path, "pfsDesign-0x{:016x}.fits".format(design_id))
+        return os.path.join(design_path, f"pfsDesign-0x{design_id:016x}.fits")

--- a/python/agActor/utils/actorCalls.py
+++ b/python/agActor/utils/actorCalls.py
@@ -6,6 +6,7 @@ def updateTelStatus(actor, logger, visit_id=None):
     actor : `actorcore.Actor`
        where to send commands and fetch results from.
     logger : `logging.Logger`
+        Logger to use.
     visit_id : int, optional
        if we know it, the visit to associate status with
 
@@ -16,11 +17,14 @@ def updateTelStatus(actor, logger, visit_id=None):
 
     # Note that visit_id can be 0 when the ag is testing or doing OTF
     if visit_id:
-        visitStr = "visit={}".format(visit_id)
+        visitStr = f"visit={visit_id}"
     else:
         visitStr = ""
+
+    logger.info(f"Calling gen2.updateTelStatus with caller={actor.name} and {visitStr=}")
+
     actor.queueCommand(
-        actor="gen2", cmdStr="updateTelStatus caller={} {}".format(actor.name, visitStr), timeLim=5
+        actor="gen2", cmdStr=f"updateTelStatus caller={actor.name} {visitStr}", timeLim=5
     ).get()
     tel_status = actor.gen2.tel_status
 

--- a/python/agActor/utils/focus.py
+++ b/python/agActor/utils/focus.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from agActor.coordinates import FieldAcquisitionAndFocusing
+from agActor.utils.logging import log_message
 from agActor.utils.opdb import opDB as opdb
 
 # mapping of keys and value types between focus.py and FieldAcquisitionAndFocusing.py
@@ -23,10 +24,10 @@ def _map_kwargs(kwargs):
 
 def focus(*, frame_id, logger=None, **kwargs):
 
-    logger and logger.info("frame_id={}".format(frame_id))
+    log_message(logger, f"frame_id={frame_id}")
     detected_objects = opdb.query_agc_data(frame_id)
     _kwargs = _filter_kwargs(kwargs)
-    logger and logger.info("_kwargs={}".format(_kwargs))
+    log_message(logger, f"_kwargs={_kwargs}")
     return _focus(detected_objects, logger=logger, **_kwargs)
 
 
@@ -55,10 +56,10 @@ def _focus(detected_objects, logger=None, **kwargs):
         ]
     )
     _kwargs = _map_kwargs(kwargs)
-    logger and logger.info("_kwargs={}".format(_kwargs))
+    log_message(logger, f"_kwargs={_kwargs}")
     pfs = FieldAcquisitionAndFocusing.PFS()
     dzs = pfs.Focus(_detected_objects, **_kwargs)
-    logger and logger.info("dzs={}".format(dzs))
+    log_message(logger, f"dzs={dzs}")
     dz = np.nanmedian(dzs)
-    logger and logger.info("dz={}".format(dz))
+    log_message(logger, f"dz={dz}")
     return dz, dzs

--- a/python/agActor/utils/logging.py
+++ b/python/agActor/utils/logging.py
@@ -1,0 +1,19 @@
+import logging
+
+
+def log_message(logger: logging.Logger, message: str, level: str | int = "INFO"):
+    """Log a message at the specified log level if logger is provided.
+
+    Args:
+        logger: Logger object to use for logging. If None, no logging occurs.
+        message: The message string to log.
+        level: The logging level as string or int. Defaults to "INFO".
+    """
+    if logger is not None:
+        if isinstance(level, str):
+            try:
+                level = getattr(logging, level.upper())
+            except AttributeError:
+                raise ValueError(f"Invalid logging level: {level}")
+
+        logger.log(level, message)

--- a/python/agActor/utils/telescope_center.py
+++ b/python/agActor/utils/telescope_center.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from agActor.catalog.pfs_design import pfsDesign as pfs_design
+from agActor.utils.logging import log_message
 
 
 class telCenter:
@@ -18,7 +19,7 @@ class telCenter:
     ):
 
         self._actor = actor
-        self._logger = logger if logger is not None else actor.logger if actor is not None else None
+        self._logger = logger or (actor.logger if actor else None)
         self._center = (
             center
             if center is not None
@@ -39,11 +40,11 @@ class telCenter:
             center = self._center
         else:
             tel_status = self._tel_status if self._tel_status is not None else self._actor.gen2.tel_status
-            self._logger and self._logger.info("tel_status={}".format(tel_status))
+            log_message(self._logger, f"tel_status={tel_status}")
             tel_guide = self._tel_guide if self._tel_guide is not None else self._actor.gen2.tel_guide
-            self._logger and self._logger.info("tel_guide={}".format(tel_guide))
+            log_message(self._logger, f"tel_guide={tel_guide}")
             tel_dither = self._tel_dither if self._tel_dither is not None else self._actor.gen2.tel_dither
-            self._logger and self._logger.info("tel_dither={}".format(tel_dither))
+            log_message(self._logger, f"tel_dither={tel_dither}")
             ra, dec, inst_pa = tel_status[
                 5:8
             ]  # command ra, dec, and inst_pa (including dither offsets and guide offsets)
@@ -54,17 +55,17 @@ class telCenter:
             inst_pa -= (tel_guide["insrot"] + tel_dither["pa"]) / 3600
             center = ra, dec, inst_pa
             self._center = center
-        self._logger and self._logger.info("center={}".format(center))
+        log_message(self._logger, f"center={center}")
         return center
 
     @property
     def dither(self):
 
         tel_guide = self._tel_guide if self._tel_guide is not None else self._actor.gen2.tel_guide
-        self._logger and self._logger.info("tel_guide={}".format(tel_guide))
+        log_message(self._logger, f"tel_guide={tel_guide}")
         if self._center is not None:
             tel_dither = self._tel_dither if self._tel_dither is not None else self._actor.gen2.tel_dither
-            self._logger and self._logger.info("tel_dither={}".format(tel_dither))
+            log_message(self._logger, f"tel_dither={tel_dither}")
             dec = self._center[1] + tel_dither["dec"] / 3600
             dither = (
                 self._center[0] + tel_dither["ra"] / float(np.cos(np.deg2rad(dec))) / 3600,
@@ -73,24 +74,24 @@ class telCenter:
             )
         else:
             tel_status = self._tel_status if self._tel_status is not None else self._actor.gen2.tel_status
-            self._logger and self._logger.info("tel_status={}".format(tel_status))
+            log_message(self._logger, f"tel_status={tel_status}")
             dither = (
                 tel_status[5] - tel_guide["ra"] / 3600,
                 tel_status[6] - tel_guide["dec"] / 3600,
                 tel_status[7] - tel_guide["insrot"] / 3600,
             )
         offset = 0, 0, 0, -tel_guide["insrot"]
-        self._logger and self._logger.info("dither={},offset={}".format(dither, offset))
+        log_message(self._logger, f"dither={dither},offset={offset}")
         return dither, offset
 
     @property
     def offset(self):
 
         tel_guide = self._tel_guide if self._tel_guide is not None else self._actor.gen2.tel_guide
-        self._logger and self._logger.info("tel_guide={}".format(tel_guide))
+        log_message(self._logger, f"tel_guide={tel_guide}")
         if self._center is not None:
             tel_dither = self._tel_dither if self._tel_dither is not None else self._actor.gen2.tel_dither
-            self._logger and self._logger.info("tel_dither={}".format(tel_dither))
+            log_message(self._logger, f"tel_dither={tel_dither}")
             dec = self._center[1] + tel_dither["dec"] / 3600
             offset = (
                 tel_dither["ra"] / float(np.cos(np.deg2rad(dec))),
@@ -100,5 +101,5 @@ class telCenter:
             )
         else:
             offset = -tel_guide["ra"], -tel_guide["dec"], -tel_guide["insrot"], -tel_guide["insrot"]
-        self._logger and self._logger.info("offset={}".format(offset))
+        log_message(self._logger, f"offset={offset}")
         return offset


### PR DESCRIPTION
* Replacing verbose `logger and logger.info` calls.
* Adding some consistency to the logging via f-strings, which is not the preferred way to do things with python logging, but is better than `format` calls.
* A few other misc format-to-f-string replacements. Some of these are in calls to `cmd.inform`, etc, which shouldn't matter but is noted.

Note that the logging overall could be improved and made more consistent rather than passing the `logger` object around to various methods, but that is a slightly more involved change.