### PR TITLE
Update gaia db connection - tickets/INSTRM-2613

### DIFF
--- a/python/agActor/Commands/AgCmd.py
+++ b/python/agActor/Commands/AgCmd.py
@@ -8,11 +8,9 @@ import opscore.protocols.types as types
 from pfs.utils.coordinates import Subaru_POPT2_PFS
 
 from agActor import field_acquisition
-from agActor.catalog import pfs_design
 from agActor.Controllers.ag import ag
-from agActor.utils import actorCalls
-from agActor.utils import data as data_utils
-from agActor.utils import focus as _focus
+from agActor.catalog import pfs_design
+from agActor.utils import actorCalls, data as data_utils, focus as _focus
 from agActor.utils.telescope_center import telCenter as tel_center
 
 
@@ -98,6 +96,10 @@ class AgCmd:
             keys.Key("exposure_delay", types.Int(), help=""),
             keys.Key("tec_off", types.Bool("no", "yes"), help=""),
         )
+
+        self.db_params = actor.actorConfig.get("db", {})
+        self.actor.logger.info(f"Database connection parameters: {self.db_params}")
+
         self.with_opdb_agc_guide_offset = actor.actorConfig.get("agc_guide_offset", False)
         self.with_opdb_agc_match = actor.actorConfig.get("agc_match", False)
         self.with_agcc_timestamp = actor.actorConfig.get("agcc_timestamp", False)
@@ -286,7 +288,12 @@ class AgCmd:
                     "AgCmd.acquire_field: Calling field_acquisition.acquire_field for guiding"
                 )
                 guide_offsets = field_acquisition.acquire_field(
-                    design=design, frame_id=frame_id, altazimuth=True, logger=self.actor.logger, **kwargs
+                    design=design,
+                    frame_id=frame_id,
+                    db_params=self.db_params,
+                    altazimuth=True,
+                    logger=self.actor.logger,
+                    **kwargs,
                 )  # design takes precedence over center
                 ra = guide_offsets.ra
                 dec = guide_offsets.dec
@@ -345,7 +352,11 @@ class AgCmd:
                     "AgCmd.acquire_field: Calling field_acquisition.acquire_field not guiding"
                 )
                 guide_offsets = field_acquisition.acquire_field(
-                    design=design, frame_id=frame_id, logger=self.actor.logger, **kwargs
+                    design=design,
+                    frame_id=frame_id,
+                    db_params=self.db_params,
+                    logger=self.actor.logger,
+                    **kwargs,
                 )  # design takes precedence over center
                 ra = guide_offsets.ra
                 dec = guide_offsets.dec

--- a/python/agActor/Controllers/ag.py
+++ b/python/agActor/Controllers/ag.py
@@ -219,6 +219,7 @@ class AgThread(threading.Thread):
         self.__abort = threading.Event()
         self.__stop = threading.Event()
 
+        self.db_params = actor.actorConfig.get("db", {})
         self.with_opdb_agc_guide_offset = actor.actorConfig.get("agc_guide_offset", False)
         self.with_opdb_agc_match = actor.actorConfig.get("agc_match", False)
         self.with_agcc_timestamp = actor.actorConfig.get("agcc_timestamp", False)
@@ -327,7 +328,7 @@ class AgThread(threading.Thread):
 
                         self.logger.info("AgThread.run: REF_OTF set_design and set_design_ac")
                         autoguide.set_design(logger=self.logger, **kwargs)
-                        autoguide.set_design_agc(logger=self.logger, **kwargs)
+                        autoguide.set_design_agc(db_params=self.db_params, logger=self.logger, **kwargs)
                         mode &= ~ag.Mode.REF_OTF
                         self._set_params(mode=mode)
                 if mode & ag.Mode.REF_DB:
@@ -338,7 +339,9 @@ class AgThread(threading.Thread):
                         kwargs["magnitude"] = options.get("magnitude")
 
                     self.logger.info("AgThread.run: REF_DB set_design and set_design_ac")
-                    autoguide.set_design_agc(logger=self.logger, **kwargs)  # obstime=<current time>
+                    autoguide.set_design_agc(
+                        db_params=self.db_params, logger=self.logger, **kwargs
+                    )  # obstime=<current time>
                     mode &= ~ag.Mode.REF_DB
                     self._set_params(mode=mode)
                 if mode & (ag.Mode.ON | ag.Mode.ONCE | ag.Mode.REF_SKY):
@@ -417,7 +420,7 @@ class AgThread(threading.Thread):
                     if mode & ag.Mode.REF_OTF:
                         self.logger.info("AgThread.run: REF_OTF set_design and set_design_ac")
                         autoguide.set_design(logger=self.logger, **kwargs)
-                        autoguide.set_design_agc(logger=self.logger, **kwargs)
+                        autoguide.set_design_agc(db_params=self.db_params, logger=self.logger, **kwargs)
                         mode &= ~ag.Mode.REF_OTF
                         self._set_params(mode=mode)
                     # retrieve detected objects from opdb
@@ -427,7 +430,9 @@ class AgThread(threading.Thread):
                         autoguide.set_design(
                             design=design, logger=self.logger, **kwargs
                         )  # center takes precedence over design
-                        autoguide.set_design_agc(frame_id=frame_id, logger=self.logger, **kwargs)
+                        autoguide.set_design_agc(
+                            frame_id=frame_id, db_params=self.db_params, logger=self.logger, **kwargs
+                        )
                         mode &= ~ag.Mode.REF_SKY
                         self._set_params(mode=mode)
                     else:  # mode & (ag.Mode.ON | ag.Mode.ONCE)

--- a/python/agActor/autoguide.py
+++ b/python/agActor/autoguide.py
@@ -46,7 +46,7 @@ def set_design(*, logger=None, **kwargs):
     Field.guide_objects = []  # delay loading of guide objects
 
 
-def set_design_agc(*, frame_id=None, obswl=0.62, logger=None, **kwargs):
+def set_design_agc(*, frame_id=None, db_params: dict | None = None, obswl=0.62, logger=None, **kwargs):
     """Set up guide objects for the current field for autoguiding.
 
     This function retrieves guide objects from various sources and stores them in Field.guide_objects.
@@ -64,6 +64,8 @@ def set_design_agc(*, frame_id=None, obswl=0.62, logger=None, **kwargs):
     Parameters:
         frame_id (int, optional): Frame ID to use for retrieving guide objects from the
             operational database. If provided, detected objects will be queried.
+        db_params (dict, optional): Dictionary of database parameters to use. This includes the
+            `opdb` and `gaia`, each of which contain connection parameters.
         obswl (float): Observation wavelength in microns. Used for atmospheric refraction
             calculations when retrieving guide objects, by default 0.62 microns.
         logger: Logger object for logging messages during execution.
@@ -108,7 +110,9 @@ def set_design_agc(*, frame_id=None, obswl=0.62, logger=None, **kwargs):
         kwargs["detected_objects"] = detected_objects
 
     # Get guide objects using the enhanced get_guide_objects function
-    guide_object_results = get_guide_objects(frame_id=frame_id, obswl=obswl, logger=logger, **kwargs)
+    guide_object_results = get_guide_objects(
+        frame_id=frame_id, db_params=db_params, obswl=obswl, logger=logger, **kwargs
+    )
 
     guide_objects = guide_object_results.guide_objects
     log_message(logger, f"Got {len(guide_objects)} guide objects before filtering.")

--- a/python/agActor/field_acquisition.py
+++ b/python/agActor/field_acquisition.py
@@ -70,6 +70,7 @@ def parse_kwargs(kwargs):
 def acquire_field(
     *,
     frame_id: int,
+    db_params: dict | None = None,
     obswl: float = 0.62,
     altazimuth: bool = False,
     logger: Logger | None = None,
@@ -87,6 +88,8 @@ def acquire_field(
     ----------
     frame_id : int
         The frame ID to retrieve telescope status for.
+    db_params (dict, optional): Dictionary of database parameters to use. This includes the
+            `opdb` and `gaia`, each of which contain connection parameters.
     obswl : float, optional
         Observation wavelength in nm, defaults to 0.62.
     altazimuth : bool, optional
@@ -139,7 +142,9 @@ def acquire_field(
     parse_kwargs(kwargs)
 
     log_message(logger, f"Calling acquire_field with {frame_id=}, {obswl=}, {altazimuth=}")
-    guide_object_results = get_guide_objects(frame_id, obswl, logger=logger, **kwargs)
+    guide_object_results = get_guide_objects(
+        frame_id, db_params=db_params, obswl=obswl, logger=logger, **kwargs
+    )
     guide_objects = guide_object_results.guide_objects
     ra = guide_object_results.ra
     dec = guide_object_results.dec

--- a/python/agActor/utils/data.py
+++ b/python/agActor/utils/data.py
@@ -159,7 +159,9 @@ def get_telescope_status(*, frame_id, **kwargs):
     return taken_at, inr, adc, m2_pos3
 
 
-def get_guide_objects(frame_id=None, obswl: float = 0.62, logger=None, **kwargs):
+def get_guide_objects(
+    frame_id=None, db_params: dict | None = None, obswl: float = 0.62, logger=None, **kwargs
+):
     """Get the guide objects for a given frame or from other sources.
 
     The guide objects can come from four separate sources:
@@ -170,6 +172,8 @@ def get_guide_objects(frame_id=None, obswl: float = 0.62, logger=None, **kwargs)
 
     Parameters:
         frame_id (int, optional): The frame id of the frame. If None, telescope status is taken from kwargs.
+        db_params (dict, optional): Dictionary of database parameters to use. This includes the
+            `opdb` and `gaia`, each of which contain connection parameters.
         obswl (float): The observation wavelength in microns, by default 0.62.
         logger (Logger, optional): Logger for logging messages.
         **kwargs: Additional keyword arguments including:
@@ -241,8 +245,10 @@ def get_guide_objects(frame_id=None, obswl: float = 0.62, logger=None, **kwargs)
         icrs, altaz_c, frame_tc, inr, adc = gaia.setup_search_coordinates(
             ra=ra, dec=dec, obstime=taken_at, inst_pa=inst_pa, adc=adc, m2pos3=m2_pos3, obswl=obswl
         )
+
         # Search for objects
-        _objects = gaia.search(icrs.ra.deg, icrs.dec.deg)
+        gaiadb_params = db_params.get("gaia", None)
+        _objects = gaia.search(icrs.ra.deg, icrs.dec.deg, db_params=gaiadb_params)
 
         # Process search results and get structured array directly
         guide_objects = gaia.process_search_results(


### PR DESCRIPTION
* Update agActor code to use new db accessors under `ics.utils.database.gaia.GaiaDB`.
* Gets DB connection params (for `opdb` and `gaia`) from `pfs_instdata`.
* If parameters are unavailable (i.e. local testing without `pfs_instdata`) then will revert back to `GaiaDB` defaults.
* Logging and other minor cleanup.

Closes INSTRM-2613