### PR TITLE
EngRun Updates - 09-12-2025

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [1.1.36] - 2025-09-13
+- EngRun-Sept-2025-09-12 - EngRun updates from 09-12-2025:
+  - Make the NON_BINARY check part of the regular checks for guiding.
+  - Don't return a series for a single agc match.
+  - Change the `MAX_CORRECTION` default to `0.5` arcsec to match what's on the SA reconfigure screen.
+  - Fix the matched guide objects index. See INSTRM-2683
+
+## [1.1.35] - 2025-09-12
 - EngRun-Sept-2025 - EngRun updates from 09-11-2025:
   - Fix the "spot size" (seeing) sent to mlp1
   - Send `np.nan` instead of `None` values in `guideErrors`.

--- a/python/agActor/Controllers/ag.py
+++ b/python/agActor/Controllers/ag.py
@@ -49,7 +49,7 @@ class ag:
     MAX_SIZE = 20.0  # pix
     MIN_SIZE = 0.92  # pix
     MAX_RESIDUAL = 0.2  # mm
-    MAX_CORRECTION = 10.0  # arcsec
+    MAX_CORRECTION = 0.5  # arcsec
     EXPOSURE_DELAY = 100  # ms
     TEC_OFF = False
 

--- a/python/agActor/coordinates/FieldAcquisitionAndFocusing.py
+++ b/python/agActor/coordinates/FieldAcquisitionAndFocusing.py
@@ -128,14 +128,14 @@ def calculate_offsets(
 
     pfs = Subaru_POPT2_PFS_AG.PFS()
 
-    logger.info(f"Guide object before filtering: {len(guide_objects)=}")
+    logger.info(f"Guide object before filtering: {len(guide_objects)}")
     try:
         good_guide_objects = guide_objects.query('filtered_by == 0')
     except KeyError:
         logger.info(f"guide_objects missing 'filtered_by' attribute, using all objects")
         good_guide_objects = guide_objects
 
-    logger.info(f"Using {len(good_guide_objects)} guide objects for basis vectors")
+    logger.info(f"Guide objects after filtering: {len(good_guide_objects)}")
 
     ra_values = good_guide_objects.ra.values
     dec_values = good_guide_objects.dec.values
@@ -144,8 +144,6 @@ def calculate_offsets(
     basis_vector_0, basis_vector_1 = pfs.makeBasis(
         tel_ra, tel_de, ra_values, dec_values, dt, adc, instrument_rotation, m2pos3, wl
     )
-    logger.info(f"{len(basis_vector_0)=}")
-    logger.info(f"{len(basis_vector_1)=}")
 
     basis_vector_0 = np.insert(basis_vector_0, 2, magnitude_values, axis=1)
     basis_vector_1 = np.insert(basis_vector_1, 2, magnitude_values, axis=1)
@@ -168,11 +166,11 @@ def calculate_offsets(
         scaleflag,
         maxresid,
     )
-    flagged_match_idx = match_results[:, 8] == 1.0
-    logger.info(f"Matched {len(match_results[flagged_match_idx])} sources")
+    valid_resid_idx = match_results[:, 8] == 1.0
+    logger.info(f"Matched sources with valid residuals: {len(match_results[valid_resid_idx])}")
 
     residual_squares = match_results[:, 6] ** 2 + match_results[:, 7] ** 2
-    residual_squares[flagged_match_idx] = np.nan
+    residual_squares[valid_resid_idx] = np.nan
 
     with warnings.catch_warnings():
         warnings.simplefilter("error", RuntimeWarning)

--- a/python/agActor/field_acquisition.py
+++ b/python/agActor/field_acquisition.py
@@ -372,7 +372,8 @@ def get_guide_offsets(
     match_results_df.index = detected_objects[valid_detections].index
     match_results_df.index.name = 'detected_object_id'
     match_results_df.reset_index(inplace=True)
-    match_results_df.guide_object_id = match_results_df.guide_object_id.astype(int)
+    matched_guide_idx = match_results_df.guide_object_id.values
+    match_results_df.guide_object_id = good_guide_objects.iloc[matched_guide_idx].index
 
     match_results_df['agc_camera_id'] = detected_objects.loc[match_results_df.detected_object_id]['agc_camera_id'].values
 
@@ -409,7 +410,7 @@ def get_guide_offsets(
             'matched',
     ]]
 
-    logger.info(f"Identified objects: {len(identified_objects)}")
+    logger.info(f"Identified objects: {len(identified_objects)} Number valid: {len(identified_objects.query('matched == 1'))}")
     if len(identified_objects) == 0:
         logger.warning(f"No detected objects detected, offsets will be zero.")
 


### PR DESCRIPTION
* Make the `NON_BINARY` check part of the regular checks for guiding.
* Don't return a series for a single agc match.
* Change the `MAX_CORRECTION` default to `0.5` arcsec to match what's on the SA reconfigure screen.
* Fix the matched guide objects index.