### PR TITLE
Handle timeouts differently from errors - tickets/INSTRM-2686

### DIFF
--- a/python/agActor/Controllers/ag.py
+++ b/python/agActor/Controllers/ag.py
@@ -662,6 +662,9 @@ class AgThread(threading.Thread):
                     self.logger.info("AgThread.run: STOP")
                     cmd.inform("guideReady=0")
                     self._set_params(mode=ag.Mode.OFF)
+            except TimeoutError as e:
+                self.logger.error(f"AgThread.run: Timeout: {e}")
+                self.logger.warning("AgThread.run: Going to next iteration because of timeout")
             except Exception as e:
                 self.logger.error(f"AgThread.run error: {e}")
                 self.logger.error("AgThread.run: stopping run loop due to error")

--- a/python/agActor/main.py
+++ b/python/agActor/main.py
@@ -93,14 +93,19 @@ class AgActor(ICC):
                         if not self.connector.isConnected():
                             raise Exception(f"connection lost: params={self.params}")
 
-                # Log out the command result.
+                # Log out the command result. Look for any timeouts.
+                found_timeout = False
                 for reply in cmd_result.replyList:
                     self.logger.info(f"reply={reply.canonical()}")
+                    found_timeout = "F timeout" in reply.canonical()
 
                 # Log out whether the command failed.
                 self.logger.info(f"didFail={cmd_result.didFail}")
                 if cmd_result.didFail:
-                    raise Exception(f"command failed: params={self.params}")
+                    if found_timeout:
+                        raise TimeoutError(f"command timeout: params={self.params}")
+                    else:
+                        raise Exception(f"command failed: params={self.params}")
 
                 return cmd_result
 


### PR DESCRIPTION
* If the `queueCommand` receives a timeout instead of an error then skip the run loop iteration rather than break the loop.

@CraigLoomis how robust is this check for a timeout in the `main.py`?

@yukimoritani suggested we keep track of the number of timeouts and if e.g. 3 happen in a row then raise Exception and break loop. TBD.