### PR TITLE
Apply dither offsets in autoguide matching - tickets/INSTRM-2896

### DIFF
--- a/python/agActor/autoguide.py
+++ b/python/agActor/autoguide.py
@@ -88,6 +88,20 @@ def get_exposure_offsets(
     dec = guide_catalog.dec
     inst_pa = guide_catalog.inst_pa
 
+    if "dra" in kwargs:
+        ra += kwargs.get("dra") / 3600
+        logger.info(f"ra modified by dra: {ra=}")
+    if "ddec" in kwargs:
+        dec += kwargs.get("ddec") / 3600
+        logger.info(f"dec modified by ddec: {dec=}")
+    if "dpa" in kwargs:
+        inst_pa += kwargs.get("dpa") / 3600
+        logger.info(f"inst_pa modified by dpa: {inst_pa=}")
+    if "dinr" in kwargs:
+        # Note: inr is updated but calculate_guide_offsets uses inst_pa for matching.
+        inr += kwargs.get("dinr") / 3600
+        logger.info(f"inr modified by dinr: {inr=}")
+
     logger.info(
         "Calling field_acquisition.calculate_guide_offsets from autoguide.get_exposure_offsets"
     )


### PR DESCRIPTION
In get_exposure_offsets, apply dra, ddec, and dpa/dinr offsets to the RA, Dec, and inst_pa before matching detected objects. These offsets, which include telescope dither and guide corrections, were being parsed from kwargs but previously ignored during the autoguide loop, causing matching to fail or be inaccurate when the telescope was offset from the design center.