### PR TITLE
Allow autoguide when no guide objects - tickets/INSTRM-2210

### DIFF
--- a/python/agActor/Controllers/ag.py
+++ b/python/agActor/Controllers/ag.py
@@ -301,9 +301,15 @@ class AgThread(threading.Thread):
                         self.logger.info(
                             f"Loading guide objects from database for {design_id=} {visit0=}"
                         )
-                        guide_catalog = get_guide_objects(
-                            design_id=design_id, visit0=visit0, is_guide=True
-                        )
+                        try:
+                            guide_catalog = get_guide_objects(
+                                design_id=design_id, visit0=visit0, is_guide=True
+                            )
+                        except RuntimeError as e:
+                            self.logger.warning(
+                                f"AgThread.run: Failed to load guide objects from database: {e}"
+                            )
+                            guide_catalog = None
 
                     # Do the actual AG exposure.
                     exposure_delay = options.get("exposure_delay", ag.EXPOSURE_DELAY)
@@ -414,6 +420,14 @@ class AgThread(threading.Thread):
                     self.logger.info(
                         f"AgThread.run: autoguide.autoguide for {frame_id=}"
                     )
+
+                    if guide_catalog is None:
+                        self.logger.warning(
+                            f"AgThread.run: No guide catalog available for {design_id=} {visit0=}, "
+                            f"skipping autoguide for this exposure"
+                        )
+                        continue
+
                     guide_offsets = autoguide.get_exposure_offsets(
                         frame_id=frame_id,
                         guide_catalog=guide_catalog,


### PR DESCRIPTION
* This will allow the `autoguide` command to continue even if no guide objects are present. 

Note: This might want some additional checks on it.