### PR TITLE
Only use the `enabled` cameras for offset calculations - tickets/INSTRM-2919

### DIFF
--- a/python/agActor/Commands/AgCmd.py
+++ b/python/agActor/Commands/AgCmd.py
@@ -173,6 +173,9 @@ class AgCmd:
         OpDB.set_default_connection(**db_params.get("opdb", {}))
         GaiaDB.set_default_connection(**db_params.get("gaia", {}))
 
+        # Enabled cameras are configured as one-indexed ids, e.g. [1, 2, 3].
+        self.enabledCameras = list(actor.actorConfig.get("enabledCameras", [1, 2, 3, 4, 5, 6]))
+
         self.with_opdb_agc_guide_offset = actor.actorConfig.get(
             "agc_guide_offset", False
         )
@@ -411,6 +414,7 @@ class AgCmd:
                 design_id=design_id,
                 visit0=visit0,
                 frame_id=frame_id,
+                cameras=self.enabledCameras,
                 **kwargs,
             )
 
@@ -644,7 +648,6 @@ class AgCmd:
         if "visit0" in cmd.cmd.keywords:
             visit0 = int(cmd.cmd.keywords["visit0"].values[0])
 
-
         from_sky = None
         if "from_sky" in cmd.cmd.keywords:
             from_sky = bool(cmd.cmd.keywords["from_sky"].values[0])
@@ -709,6 +712,7 @@ class AgCmd:
                 exposure_time=exposure_time,
                 cadence=cadence,
                 center=center,
+                enabledCameras=self.enabledCameras,
                 **kwargs,
             )
         except Exception as e:

--- a/python/agActor/Commands/AgCmd.py
+++ b/python/agActor/Commands/AgCmd.py
@@ -174,7 +174,7 @@ class AgCmd:
         GaiaDB.set_default_connection(**db_params.get("gaia", {}))
 
         # Enabled cameras are configured as one-indexed ids, e.g. [1, 2, 3].
-        self.enabledCameras = list(actor.actorConfig.get("enabledCameras", [1, 2, 3, 4, 5, 6]))
+        self.enabledCameras = list(actor.actorConfig.get("enabled", [1, 2, 3, 4, 5, 6]))
 
         self.with_opdb_agc_guide_offset = actor.actorConfig.get(
             "agc_guide_offset", False

--- a/python/agActor/Commands/AgCmd.py
+++ b/python/agActor/Commands/AgCmd.py
@@ -465,6 +465,7 @@ class AgCmd:
             self.actor.logger.info("AgCmd.acquire_field: Calling focus")
             dz, dzs = focus(
                 detected_objects=guide_offsets.detected_objects,
+                enabledCameras=self.enabledCameras,
                 max_ellipticity=max_ellipticity,
                 max_size=max_size,
                 min_size=min_size,
@@ -582,6 +583,7 @@ class AgCmd:
             # compute focus offset and tilt
             dz, dzs = focus(
                 frame_id=frame_id,
+                enabledCameras=self.enabledCameras,
                 max_ellipticity=max_ellipticity,
                 max_size=max_size,
                 min_size=min_size,

--- a/python/agActor/Controllers/ag.py
+++ b/python/agActor/Controllers/ag.py
@@ -609,7 +609,6 @@ class AgThread(threading.Thread):
             end = time.time()
             elapsed = end - start
             timeout = (max(0, cadence / 1000 - elapsed) if mode & ag.Mode.ON else 0.5)
-            self.logger.debug(f"AgThread.run: Control loop delay {timeout=:.3f} {self.__abort.is_set()=}")
             self.__abort.wait(timeout)
 
         cmd.inform("guideReady=0")

--- a/python/agActor/Controllers/ag.py
+++ b/python/agActor/Controllers/ag.py
@@ -50,6 +50,7 @@ class ag:
             "exposure_time",
             "cadence",
             "center",
+            "cameras",
             "options",
         )
 
@@ -121,9 +122,12 @@ class ag:
         exposure_time=EXPOSURE_TIME,
         cadence=CADENCE,
         center=None,
+        enabledCameras: list[int] | None = None,
         **kwargs,
     ):
         mode = ag.Mode.AUTO_DB
+
+        cameras = enabledCameras or [1, 2, 3, 4, 5, 6]
 
         self.logger.info(
             f"start_autoguide: {mode=},{design=},{visit_id=},{exposure_time=},{cadence=},{center=}"
@@ -137,6 +141,7 @@ class ag:
             exposure_time=exposure_time,
             cadence=cadence,
             center=center,
+            cameras=cameras,
             options={},
             **kwargs,
         )
@@ -273,7 +278,7 @@ class AgThread(threading.Thread):
 
             try:
                 start = time.time()
-                mode, design, visit_id, visit0, exposure_time, cadence, center, options = (
+                mode, design, visit_id, visit0, exposure_time, cadence, center, cameras, options = (
                     self._get_params()
                 )
 
@@ -417,6 +422,7 @@ class AgThread(threading.Thread):
                     guide_offsets = autoguide.get_exposure_offsets(
                         frame_id=frame_id,
                         guide_catalog=guide_catalog,
+                        cameras=cameras,
                         max_ellipticity=max_ellipticity,
                         max_size=max_size,
                         min_size=min_size,

--- a/python/agActor/Controllers/ag.py
+++ b/python/agActor/Controllers/ag.py
@@ -127,7 +127,7 @@ class ag:
     ):
         mode = ag.Mode.AUTO_DB
 
-        cameras = enabledCameras or [1, 2, 3, 4, 5, 6]
+        cameras = enabledCameras if enabledCameras is not None else [1, 2, 3, 4, 5, 6]
 
         self.logger.info(
             f"start_autoguide: {mode=},{design=},{visit_id=},{exposure_time=},{cadence=},{center=}"

--- a/python/agActor/Controllers/ag.py
+++ b/python/agActor/Controllers/ag.py
@@ -511,6 +511,7 @@ class AgThread(threading.Thread):
 
                     dz, dzs = focus(
                         detected_objects=_detected_objects,
+                        enabledCameras=cameras,
                         max_ellipticity=max_ellipticity,
                         max_size=max_size,
                         min_size=min_size,

--- a/python/agActor/autoguide.py
+++ b/python/agActor/autoguide.py
@@ -37,8 +37,10 @@ def get_exposure_offsets(
     Parameters:
         frame_id (int): Frame ID to use for retrieving detected objects and telescope status.
         guide_catalog (GuideCatalog): Guide objects and field center information.
-        cameras (list[int] or None): Optional list of one-indexed camera ids to use for
-            calculating offsets. If None, all cameras are used.
+        cameras (list[int] or None): Optional list of one-indexed camera ids whose
+            detections are allowed to contribute to the astrometric fit.
+            Detections from all cameras are still fetched; only the fit is
+            restricted.  If None, all cameras contribute to the fit.
         obswl (float): Observation wavelength in microns, used for atmospheric refraction
             calculations, by default 0.62 microns.
         max_ellipticity (float): Maximum ellipticity for source filtering, by default 2.0e0.
@@ -85,7 +87,7 @@ def get_exposure_offsets(
         filter_flags = filter_flags | SourceDetectionFlag.BAD_SHAPE
     else:
         filter_flags = filter_flags & ~SourceDetectionFlag.BAD_SHAPE
-    detected_objects = get_detected_objects(frame_id, filter_flags=filter_flags, cameras=cameras)
+    detected_objects = get_detected_objects(frame_id, filter_flags=filter_flags)
 
     ra = guide_catalog.ra
     dec = guide_catalog.dec
@@ -123,6 +125,7 @@ def get_exposure_offsets(
         max_size=max_size,
         min_size=min_size,
         max_residual=max_residual,
+        enabled_camera_ids=cameras,
     )
 
     guide_offsets.ra = ra

--- a/python/agActor/autoguide.py
+++ b/python/agActor/autoguide.py
@@ -18,6 +18,7 @@ def get_exposure_offsets(
     *,
     frame_id: int,
     guide_catalog: GuideCatalog,
+    cameras: list[int] | None = None,
     obswl: float = 0.62,
     max_ellipticity: float = 2.0e0,
     max_size: float = 1.0e12,
@@ -36,6 +37,8 @@ def get_exposure_offsets(
     Parameters:
         frame_id (int): Frame ID to use for retrieving detected objects and telescope status.
         guide_catalog (GuideCatalog): Guide objects and field center information.
+        cameras (list[int] or None): Optional list of one-indexed camera ids to use for
+            calculating offsets. If None, all cameras are used.
         obswl (float): Observation wavelength in microns, used for atmospheric refraction
             calculations, by default 0.62 microns.
         max_ellipticity (float): Maximum ellipticity for source filtering, by default 2.0e0.
@@ -82,7 +85,7 @@ def get_exposure_offsets(
         filter_flags = filter_flags | SourceDetectionFlag.BAD_SHAPE
     else:
         filter_flags = filter_flags & ~SourceDetectionFlag.BAD_SHAPE
-    detected_objects = get_detected_objects(frame_id, filter_flags=filter_flags)
+    detected_objects = get_detected_objects(frame_id, filter_flags=filter_flags, cameras=cameras)
 
     ra = guide_catalog.ra
     dec = guide_catalog.dec

--- a/python/agActor/coordinates/FieldAcquisitionAndFocusing.py
+++ b/python/agActor/coordinates/FieldAcquisitionAndFocusing.py
@@ -126,7 +126,8 @@ def calculate_offsets(
         - Declination offset
         - Instrument rotation offset
         - Scale offset
-        - Match results array
+        - Match results array (N, 11): columns 0-9 per RADECInRShiftA docs;
+          column 10 (fit_contributor) is 1.0 for detections from enabled cameras
         - Median distance
         - Number of valid sources
     """

--- a/python/agActor/coordinates/FieldAcquisitionAndFocusing.py
+++ b/python/agActor/coordinates/FieldAcquisitionAndFocusing.py
@@ -1,6 +1,6 @@
 import logging
 import warnings
-from typing import Any, Tuple
+from typing import Any, List, Optional, Tuple
 
 import numpy as np
 import pandas as pd
@@ -70,6 +70,7 @@ def calculate_offsets(
     max_size: float = 1.0e12,
     min_size: float = -1.0e0,
     max_residual: float = 0.5,
+    enabled_camera_ids: Optional[List[int]] = None,
 ) -> Tuple[float, float, float, float, NDArray[np.float64], float, int]:
     """
     Perform field acquisition calculations with the instrument position angle.
@@ -110,6 +111,12 @@ def calculate_offsets(
         Minimum size for source filtering, by default -1.0e0.
     max_residual : float, optional
         Maximum residual for source filtering, by default 0.5
+    enabled_camera_ids : list[int] or None, optional
+        Camera IDs (1-based) whose detections may contribute to the
+        astrometric fit.  Detections from cameras not in this list are
+        still matched and included in the returned match results, but they
+        do not influence the computed offsets.  ``None`` (default) enables
+        all cameras.
 
     Returns
     -------
@@ -166,6 +173,8 @@ def calculate_offsets(
         fit_inr,
         fit_scale,
         max_residual,
+        obj_camera_id=filtered_detected_array[:, 0].astype(int),
+        enabled_camera_ids=enabled_camera_ids,
     )
     valid_resid_idx = match_results[:, 8] == 1.0
     logger.info(f"Matched sources with valid residuals: {len(match_results[valid_resid_idx])}")

--- a/python/agActor/coordinates/FieldAcquisitionAndFocusing.py
+++ b/python/agActor/coordinates/FieldAcquisitionAndFocusing.py
@@ -163,6 +163,8 @@ def calculate_offsets(
     )
     logger.info(f"Found {len(filtered_detected_array)} detected sources after filtering")
 
+    logger.info(f"Calling RADECInRShiftA with {enabled_camera_ids=}")
+
     ra_offset, de_offset, inr_offset, scale_offset, match_results = pfs.RADECInRShiftA(
         filtered_detected_array[:, 2],
         filtered_detected_array[:, 3],

--- a/python/agActor/coordinates/FieldAcquisitionAndFocusing.py
+++ b/python/agActor/coordinates/FieldAcquisitionAndFocusing.py
@@ -180,7 +180,13 @@ def calculate_offsets(
         enabled_camera_ids=enabled_camera_ids,
     )
     valid_resid_idx = match_results[:, 8] == 1.0
-    logger.info(f"Matched sources with valid residuals: {len(match_results[valid_resid_idx])}")
+    fit_contributor_mask = match_results[:, 10] == 1.0
+    n_contributor_inliers = int(np.count_nonzero(valid_resid_idx & fit_contributor_mask))
+    n_non_contributor_inliers = int(np.count_nonzero(valid_resid_idx & ~fit_contributor_mask))
+    logger.info(
+        f"Matched sources with valid residuals: {len(match_results[valid_resid_idx])} "
+        f"(fit contributors: {n_contributor_inliers}, disabled-camera: {n_non_contributor_inliers})"
+    )
 
     residual_squares = match_results[:, 6] ** 2 + match_results[:, 7] ** 2
     residual_squares[valid_resid_idx] = np.nan

--- a/python/agActor/coordinates/FieldAcquisitionAndFocusing.py
+++ b/python/agActor/coordinates/FieldAcquisitionAndFocusing.py
@@ -150,6 +150,24 @@ def calculate_offsets(
     dec_values = good_guide_objects.dec.values
     magnitude_values = good_guide_objects.mag.values
 
+    # Guide stars from disabled cameras are intentionally left in the catalog
+    # passed to makeBasis.  Two properties make them safe to include:
+    #
+    # 1. makeBasis computes each catalog star's predicted focal-plane position
+    #    and Jacobian independently — there is no coupling between stars, so
+    #    adding extra entries cannot distort any other star's basis vector.
+    #
+    # 2. The nearest-neighbour search inside RADECInRShiftA uses a 2 mm match
+    #    threshold.  PFS AG cameras are physically ~200–250 mm apart on the
+    #    focal plane, so a guide star from a disabled camera can never be the
+    #    closest catalog match for a detection from an enabled camera.
+    #
+    # As a result, disabled-camera guide stars never win any match that feeds
+    # an enabled-camera detection into the least-squares solve.  The
+    # enabled_mask in RADECInRShiftA provides a further explicit guard on the
+    # fit itself.  Keeping them in the catalog preserves meaningful predicted
+    # focal-plane positions for disabled-camera detections in the returned
+    # match_result, which is useful for diagnostics and downstream processing.
     basis_vector_0, basis_vector_1 = pfs.makeBasis(
         tel_ra, tel_de, ra_values, dec_values, dt, adc, instrument_rotation, m2pos3, wl
     )

--- a/python/agActor/coordinates/FieldAcquisitionAndFocusing.py
+++ b/python/agActor/coordinates/FieldAcquisitionAndFocusing.py
@@ -175,7 +175,7 @@ def calculate_offsets(
         fit_inr,
         fit_scale,
         max_residual,
-        obj_camera_id=filtered_detected_array[:, 0].astype(int),
+        obj_camera_id=filtered_detected_array[:, 0].astype(int) + 1,  # DB is 0-based; RADECInRShiftA expects 1-based
         enabled_camera_ids=enabled_camera_ids,
     )
     valid_resid_idx = match_results[:, 8] == 1.0

--- a/python/agActor/coordinates/FieldAcquisitionAndFocusing.py
+++ b/python/agActor/coordinates/FieldAcquisitionAndFocusing.py
@@ -127,7 +127,7 @@ def calculate_offsets(
         - Instrument rotation offset
         - Scale offset
         - Match results array (N, 11): columns 0-9 per RADECInRShiftA docs;
-          column 10 (fit_contributor) is 1.0 for detections from enabled cameras
+          column 10 (camera_enabled) is 1.0 for detections from enabled cameras
         - Median distance
         - Number of valid sources
     """
@@ -180,12 +180,12 @@ def calculate_offsets(
         enabled_camera_ids=enabled_camera_ids,
     )
     valid_resid_idx = match_results[:, 8] == 1.0
-    fit_contributor_mask = match_results[:, 10] == 1.0
-    n_contributor_inliers = int(np.count_nonzero(valid_resid_idx & fit_contributor_mask))
-    n_non_contributor_inliers = int(np.count_nonzero(valid_resid_idx & ~fit_contributor_mask))
+    camera_enabled_mask = match_results[:, 10] == 1.0
+    n_enabled_inliers = int(np.count_nonzero(valid_resid_idx & camera_enabled_mask))
+    n_disabled_inliers = int(np.count_nonzero(valid_resid_idx & ~camera_enabled_mask))
     logger.info(
         f"Matched sources with valid residuals: {len(match_results[valid_resid_idx])} "
-        f"(fit contributors: {n_contributor_inliers}, disabled-camera: {n_non_contributor_inliers})"
+        f"(enabled-camera: {n_enabled_inliers}, disabled-camera: {n_disabled_inliers})"
     )
 
     residual_squares = match_results[:, 6] ** 2 + match_results[:, 7] ** 2

--- a/python/agActor/coordinates/Subaru_POPT2_PFS_AG.py
+++ b/python/agActor/coordinates/Subaru_POPT2_PFS_AG.py
@@ -211,8 +211,10 @@ class PFS():
               7:  resid_y — post-fit residual y [mm]
               8:  is_inlier — 1.0 if the match survived outlier rejection
               9:  cat_index — index of the matched star in the catalog arrays
-              10: fit_contributor — 1.0 if this detection's camera was in
-                  enabled_camera_ids (i.e. contributed to the astrometric fit)
+              10: camera_enabled — 1.0 if this detection's camera is in
+                  enabled_camera_ids, 0.0 otherwise.  Note: a detection
+                  from an enabled camera may still not enter the fit if it
+                  had no close catalog match (distance > 2 mm).
         """
 
         # ── Phase 1: Catalog unpacking ────────────────────────────────────────
@@ -521,8 +523,8 @@ class PFS():
 
         resid_r = np.sqrt(np.sum(resid_xy**2,axis=1))
         vcx = np.array([resid_r<=rejection_threshold]).transpose()
-        fit_contributor = np.array([enabled_mask], dtype=float).transpose()
-        match_result = np.block([match_obj_xy, match_cat_xy, err_xy, resid_xy, vcx, min_dist_index.reshape(-1,1), fit_contributor])
+        camera_enabled = np.array([enabled_mask], dtype=float).transpose()
+        match_result = np.block([match_obj_xy, match_cat_xy, err_xy, resid_xy, vcx, min_dist_index.reshape(-1,1), camera_enabled])
 
         # ── Phase 7: Unit conversion ──────────────────────────────────────────
         # Multiply the dimensionless least-squares coefficients by the

--- a/python/agActor/coordinates/Subaru_POPT2_PFS_AG.py
+++ b/python/agActor/coordinates/Subaru_POPT2_PFS_AG.py
@@ -489,7 +489,12 @@ class PFS():
             # Keep exact-zero residuals in the inlier set; otherwise a perfect
             # first fit can empty the refit and collapse the solution to zeros.
             inlier_mask = resid_r <= rejection_threshold
-            inlier_flat_mask = np.concatenate([inlier_mask, inlier_mask]) & np.concatenate([enabled_mask, enabled_mask])
+            # Restrict the refit and threshold update to enabled cameras only.
+            # Disabled-camera residuals are predictions only and must not drive
+            # the rejection threshold, or they could tighten it and reject valid
+            # enabled-camera detections that the fit actually depends on.
+            enabled_inlier_mask = inlier_mask & enabled_mask
+            inlier_flat_mask = np.concatenate([enabled_inlier_mask, enabled_inlier_mask])
 
             if not np.any(inlier_flat_mask):
                 logger.warning(
@@ -510,7 +515,7 @@ class PFS():
             resid_xy = (((err-np.dot(basis,lstsq_coeffs))[:,0]).reshape([2,-1])).transpose()
             rejection_threshold_old = rejection_threshold
             resid_r = np.sqrt(np.sum(resid_xy**2,axis=1))
-            rejection_threshold = np.min(np.array([np.nanmedian(resid_r[inlier_mask])*3,max_rejection_threshold]))
+            rejection_threshold = np.min(np.array([np.nanmedian(resid_r[enabled_inlier_mask])*3,max_rejection_threshold]))
             if(rejection_threshold == rejection_threshold_old):
                 break
 

--- a/python/agActor/coordinates/Subaru_POPT2_PFS_AG.py
+++ b/python/agActor/coordinates/Subaru_POPT2_PFS_AG.py
@@ -172,12 +172,14 @@ class PFS():
             ``None`` all sources are treated as coming from an enabled camera.
         enabled_camera_ids : list[int] or None, optional
             Camera IDs whose detections are allowed to contribute to the
-            least-squares solve (Phases 5–6).  Detections from cameras
-            *not* in this list are still matched and appear in
+            coarse and least-squares solves (Phases 3–6).  Detections from
+            cameras *not* in this list are still matched and appear in
             ``match_result``, but they never enter the fit.  When ``None``
             (the default) all cameras are used, preserving the original
-            behaviour.  If the refined fit has no usable rows, the method
-            falls back to the coarse RA/Dec solution and logs a warning.
+            behaviour.  If the enabled set is empty, the coarse solve falls
+            back to all detections and logs a warning.  If the refined fit has
+            no usable rows, the method falls back to the coarse RA/Dec solution
+            and logs a warning.
 
         Returns
         -------
@@ -253,34 +255,66 @@ class PFS():
         # offset in perturbation units.  Note: InR/scale errors are not
         # corrected here — they typically dominate only at fine-guiding level,
         # not at acquisition (see plan note B5).
-        right_detector_mask = np.where((obj_flag.astype(int) & SourceDetectionFlags.RIGHT) == SourceDetectionFlags.RIGHT)
+        if enabled_camera_ids is not None and obj_camera_id is not None:
+            enabled_mask = np.isin(obj_camera_id, enabled_camera_ids)
+        else:
+            enabled_mask = np.ones(len(obj_xdp), dtype=bool)
 
-        n_obj = (obj_xdp.shape)[0]
+        coarse_mask = enabled_mask
+        if enabled_camera_ids is not None and not np.any(coarse_mask):
+            logger.warning(
+                "RADECInRShiftA coarse solve had no enabled detections; falling back to all detections. "
+                "n_obj=%d enabled_camera_ids=%s",
+                len(obj_xdp),
+                enabled_camera_ids,
+            )
+            coarse_mask = np.ones(len(obj_xdp), dtype=bool)
 
-        xdiff_0 = np.transpose([obj_xdp])-cat_xdp_0
-        ydiff_0 = np.transpose([obj_ydp])-cat_ydp_0
-        xdiff_1 = np.transpose([obj_xdp])-cat_xdp_1
-        ydiff_1 = np.transpose([obj_ydp])-cat_ydp_1
+        coarse_obj_xdp = obj_xdp[coarse_mask]
+        coarse_obj_ydp = obj_ydp[coarse_mask]
+        coarse_obj_flag = obj_flag[coarse_mask]
+        coarse_right_detector_mask = np.where(
+            (coarse_obj_flag.astype(int) & SourceDetectionFlags.RIGHT) == SourceDetectionFlags.RIGHT
+        )
+
+        coarse_n_obj = (coarse_obj_xdp.shape)[0]
+
+        xdiff_0 = np.transpose([coarse_obj_xdp]) - cat_xdp_0
+        ydiff_0 = np.transpose([coarse_obj_ydp]) - cat_ydp_0
+        xdiff_1 = np.transpose([coarse_obj_xdp]) - cat_xdp_1
+        ydiff_1 = np.transpose([coarse_obj_ydp]) - cat_ydp_1
 
         xdiff = np.copy(xdiff_0)
         ydiff = np.copy(ydiff_0)
-        xdiff[right_detector_mask]=xdiff_1[right_detector_mask]
-        ydiff[right_detector_mask]=ydiff_1[right_detector_mask]
+        xdiff[coarse_right_detector_mask] = xdiff_1[coarse_right_detector_mask]
+        ydiff[coarse_right_detector_mask] = ydiff_1[coarse_right_detector_mask]
 
-        dist  = np.sqrt(xdiff**2+ydiff**2)
+        dist = np.sqrt(xdiff**2 + ydiff**2)
 
-        min_dist_index   = np.nanargmin(dist, axis=1)
-        min_dist_indices = np.array(range(n_obj), dtype='int'),min_dist_index
+        min_dist_index = np.nanargmin(dist, axis=1)
+        min_dist_indices = np.array(range(coarse_n_obj), dtype="int"), min_dist_index
+        coarse_distances = dist[min_dist_indices]
+        coarse_min, coarse_median, coarse_max = self._distance_summary(coarse_distances)
         # Cramer's-rule solution for the RA/Dec perturbation coefficients.
         # coarse_ra_coeff and coarse_dec_coeff are still in perturbation units
         # (not arcsec).
         coarse_ra_coeff = np.median((xdiff[min_dist_indices]*dyde[min_dist_index]-ydiff[min_dist_indices]*dxde[min_dist_index])/(dxra[min_dist_index]*dyde[min_dist_index]-dyra[min_dist_index]*dxde[min_dist_index]))
         coarse_dec_coeff = np.median((xdiff[min_dist_indices]*dyra[min_dist_index]-ydiff[min_dist_indices]*dxra[min_dist_index])/(dxde[min_dist_index]*dyra[min_dist_index]-dyde[min_dist_index]*dxra[min_dist_index]))
+        logger.info(
+            "RADECInRShiftA coarse stats: n_obj=%d n_enabled=%d coarse_mm[min/med/max]=%.3f/%.3f/%.3f enabled_camera_ids=%s",
+            coarse_n_obj,
+            int(np.count_nonzero(coarse_mask)),
+            coarse_min,
+            coarse_median,
+            coarse_max,
+            enabled_camera_ids,
+        )
 
         # ── Phase 4: Refined nearest-neighbour match ──────────────────────────
         # Apply the coarse RA/Dec offset to shift the catalog positions, then
         # redo the nearest-neighbour search.  Only pairs within 2 mm of each
         # other are accepted for the least-squares solve.
+        n_obj = (obj_xdp.shape)[0]
         xdiff_0 = np.transpose([obj_xdp])-(cat_xdp_0+coarse_ra_coeff*dxra+coarse_dec_coeff*dxde)
         ydiff_0 = np.transpose([obj_ydp])-(cat_ydp_0+coarse_ra_coeff*dyra+coarse_dec_coeff*dyde)
 
@@ -289,8 +323,8 @@ class PFS():
 
         xdiff = np.copy(xdiff_0)
         ydiff = np.copy(ydiff_0)
-        xdiff[right_detector_mask]=xdiff_1[right_detector_mask]
-        ydiff[right_detector_mask]=ydiff_1[right_detector_mask]
+        xdiff[coarse_right_detector_mask] = xdiff_1[coarse_right_detector_mask]
+        ydiff[coarse_right_detector_mask] = ydiff_1[coarse_right_detector_mask]
 
         dist  = np.sqrt(xdiff**2+ydiff**2)
 
@@ -361,15 +395,6 @@ class PFS():
         # Build the design matrix (basis) by stacking the x and y Jacobian
         # columns for each enabled degree of freedom.  Only close-matched
         # pairs (close_match_mask) enter the initial solve.
-        #
-        # enabled_mask restricts the fit to detections from the requested
-        # camera IDs.  When enabled_camera_ids is None every detection is
-        # eligible (backward-compatible default).
-        if enabled_camera_ids is not None and obj_camera_id is not None:
-            enabled_mask = np.isin(obj_camera_id, enabled_camera_ids)
-        else:
-            enabled_mask = np.ones(len(obj_xdp), dtype=bool)
-
         fit_mask = close_match_mask & enabled_mask
         n_enabled = int(np.count_nonzero(enabled_mask))
         n_close = int(np.count_nonzero(close_match_mask))

--- a/python/agActor/coordinates/Subaru_POPT2_PFS_AG.py
+++ b/python/agActor/coordinates/Subaru_POPT2_PFS_AG.py
@@ -246,6 +246,7 @@ class PFS():
         dyra  = (dyra_0  + dyra_1 )/2.0
         dxde  = (dxde_0  + dxde_1 )/2.0
         dyde  = (dyde_0  + dyde_1 )/2.0
+
         # ── Phase 3: Coarse nearest-neighbour match + Cramer's rule ──────────
         # For each detected object find its nearest catalog star, then solve
         # the 2×2 linear system:
@@ -321,10 +322,17 @@ class PFS():
         xdiff_1 = np.transpose([obj_xdp])-(cat_xdp_1+coarse_ra_coeff*dxra+coarse_dec_coeff*dxde)
         ydiff_1 = np.transpose([obj_ydp])-(cat_ydp_1+coarse_ra_coeff*dyra+coarse_dec_coeff*dyde)
 
+        # Re-derive the RIGHT-detector mask from the full obj_flag here.
+        # coarse_right_detector_mask has indices into the coarse (enabled-only)
+        # subarray and must NOT be reused on the full (n_obj) arrays below.
+        right_detector_mask = np.where(
+            (obj_flag.astype(int) & SourceDetectionFlags.RIGHT) == SourceDetectionFlags.RIGHT
+        )
+
         xdiff = np.copy(xdiff_0)
         ydiff = np.copy(ydiff_0)
-        xdiff[coarse_right_detector_mask] = xdiff_1[coarse_right_detector_mask]
-        ydiff[coarse_right_detector_mask] = ydiff_1[coarse_right_detector_mask]
+        xdiff[right_detector_mask] = xdiff_1[right_detector_mask]
+        ydiff[right_detector_mask] = ydiff_1[right_detector_mask]
 
         dist  = np.sqrt(xdiff**2+ydiff**2)
 

--- a/python/agActor/coordinates/Subaru_POPT2_PFS_AG.py
+++ b/python/agActor/coordinates/Subaru_POPT2_PFS_AG.py
@@ -85,7 +85,8 @@ class PFS():
 
     def RADECInRShiftA(self, obj_xdp, obj_ydp, obj_int, obj_flag,
                        catalog_left, catalog_right,
-                       fit_inr: bool, fit_scale: bool, maxresid=0.5):
+                       fit_inr: bool, fit_scale: bool, maxresid=0.5,
+                       obj_camera_id=None, enabled_camera_ids=None):
         """Perform a full astrometric solve: match detected sources to a catalog
         and determine the pointing offsets (RA, Dec, InR, scale).
 
@@ -146,6 +147,17 @@ class PFS():
         maxresid : float, optional
             Hard upper limit on the outlier-rejection threshold [mm].
             Defaults to 0.5 mm.
+        obj_camera_id : np.ndarray, shape (N,), dtype int, optional
+            Camera / CCD index (1-based) for each detected source.  Must be
+            provided when ``enabled_camera_ids`` is not ``None``.  When
+            ``None`` all sources are treated as coming from an enabled camera.
+        enabled_camera_ids : list[int] or None, optional
+            Camera IDs whose detections are allowed to contribute to the
+            least-squares solve (Phases 5–6).  Detections from cameras
+            *not* in this list are still matched and appear in
+            ``match_result``, but they never enter the fit.  When ``None``
+            (the default) all cameras are used, preserving the original
+            behaviour.
 
         Returns
         -------
@@ -334,6 +346,16 @@ class PFS():
         # Build the design matrix (basis) by stacking the x and y Jacobian
         # columns for each enabled degree of freedom.  Only close-matched
         # pairs (close_match_mask) enter the initial solve.
+        #
+        # enabled_mask restricts the fit to detections from the requested
+        # camera IDs.  When enabled_camera_ids is None every detection is
+        # eligible (backward-compatible default).
+        if enabled_camera_ids is not None and obj_camera_id is not None:
+            enabled_mask = np.isin(obj_camera_id, enabled_camera_ids)
+        else:
+            enabled_mask = np.ones(len(obj_xdp), dtype=bool)
+
+        fit_mask = close_match_mask & enabled_mask
         dra  = np.concatenate([match_dxra,match_dyra])
         dde  = np.concatenate([match_dxde,match_dyde])
         dinr = np.concatenate([match_dxinr,match_dyinr])
@@ -352,8 +374,8 @@ class PFS():
         erry = match_obj_ydp - match_cat_ydp
         err  = np.array([np.concatenate([errx,erry])]).transpose()
 
-        newbasis = basis[np.concatenate([close_match_mask,close_match_mask])]
-        newerr   = err[np.concatenate([close_match_mask,close_match_mask])]
+        newbasis = basis[np.concatenate([fit_mask, fit_mask])]
+        newerr   = err[np.concatenate([fit_mask, fit_mask])]
         lstsq_coeffs, residual, rank, sv = np.linalg.lstsq(newbasis, newerr, rcond = None)
 
         match_obj_xy = np.stack([match_obj_xdp,match_obj_ydp]).transpose()
@@ -371,7 +393,7 @@ class PFS():
         for rej_itr in range(5):
             resid_r = np.sqrt(np.sum(resid_xy**2,axis=1))
 
-            inlier_flat_mask  = np.where(np.concatenate([resid_r, resid_r], 0) < rejection_threshold)
+            inlier_flat_mask  = np.where(np.concatenate([resid_r < rejection_threshold, resid_r < rejection_threshold], 0) & np.concatenate([enabled_mask, enabled_mask], 0))
             inlier_mask = np.where(np.concatenate([resid_r], 0) < rejection_threshold)
 
             basis2 = basis[inlier_flat_mask]

--- a/python/agActor/coordinates/Subaru_POPT2_PFS_AG.py
+++ b/python/agActor/coordinates/Subaru_POPT2_PFS_AG.py
@@ -15,9 +15,15 @@ d_scl = 1.0e-05
 
 class PFS():
     def _build_coefficients(self, ra_coeff, de_coeff, fit_inr, fit_scale):
-        """Build a least-squares coefficient vector for the active fit terms."""
+        """Build a least-squares coefficient vector for the active fit terms.
+
+        Slots for RA and Dec are set to the supplied coarse estimates.  Any
+        InR and scale slots are filled with NaN so that the caller's unit-
+        conversion step produces NaN for those offsets (matching the
+        convention used when fit_inr / fit_scale are False).
+        """
         coeff_count = 2 + int(fit_inr) + int(fit_scale)
-        coeffs = np.zeros((coeff_count, 1))
+        coeffs = np.full((coeff_count, 1), np.nan)
         coeffs[0, 0] = ra_coeff
         coeffs[1, 0] = de_coeff
         return coeffs

--- a/python/agActor/coordinates/Subaru_POPT2_PFS_AG.py
+++ b/python/agActor/coordinates/Subaru_POPT2_PFS_AG.py
@@ -1,6 +1,10 @@
+import logging
+
 import numpy as np
 from pfs.utils.coordinates import Subaru_POPT2_PFS as pfs
 from pfs.utils.datamodel.ag import SourceDetectionFlags
+
+logger = logging.getLogger(__name__)
 
 ### perturbation
 d_ra  = 1.0/3600.0
@@ -10,6 +14,21 @@ d_scl = 1.0e-05
 
 
 class PFS():
+    def _build_coefficients(self, ra_coeff, de_coeff, fit_inr, fit_scale):
+        """Build a least-squares coefficient vector for the active fit terms."""
+        coeff_count = 2 + int(fit_inr) + int(fit_scale)
+        coeffs = np.zeros((coeff_count, 1))
+        coeffs[0, 0] = ra_coeff
+        coeffs[1, 0] = de_coeff
+        return coeffs
+
+    def _distance_summary(self, distances):
+        """Return min/median/max for a 1-D array, ignoring non-finite values."""
+        finite = np.asarray(distances)[np.isfinite(distances)]
+        if finite.size == 0:
+            return np.nan, np.nan, np.nan
+        return float(np.min(finite)), float(np.median(finite)), float(np.max(finite))
+
     def sourceFilter(self, agarray, maxellip, maxsize, minsize):
         """Filter detected AG sources by shape quality criteria.
 
@@ -157,7 +176,8 @@ class PFS():
             *not* in this list are still matched and appear in
             ``match_result``, but they never enter the fit.  When ``None``
             (the default) all cameras are used, preserving the original
-            behaviour.
+            behaviour.  If the refined fit has no usable rows, the method
+            falls back to the coarse RA/Dec solution and logs a warning.
 
         Returns
         -------
@@ -224,11 +244,6 @@ class PFS():
         dyra  = (dyra_0  + dyra_1 )/2.0
         dxde  = (dxde_0  + dxde_1 )/2.0
         dyde  = (dyde_0  + dyde_1 )/2.0
-        dxinr = (dxinr_0 + dxinr_1)/2.0
-        dyinr = (dyinr_0 + dyinr_1)/2.0
-        dxscl = (dxscl_0 + dxscl_1)/2.0
-        dyscl = (dyscl_0 + dyscl_1)/2.0
-
         # ── Phase 3: Coarse nearest-neighbour match + Cramer's rule ──────────
         # For each detected object find its nearest catalog star, then solve
         # the 2×2 linear system:
@@ -284,10 +299,10 @@ class PFS():
 
         # Boolean mask: True where the refined match distance is within 2 mm.
         close_match_mask  = dist[min_dist_indices] < 2.0
+        nearest_distances = dist[min_dist_indices]
 
         match_obj_xdp  = obj_xdp
         match_obj_ydp  = obj_ydp
-        match_obj_int  = obj_int
         match_obj_flag = obj_flag
 
         match_cat_xdp_0 = (cat_xdp_0[min_dist_index])
@@ -356,6 +371,23 @@ class PFS():
             enabled_mask = np.ones(len(obj_xdp), dtype=bool)
 
         fit_mask = close_match_mask & enabled_mask
+        n_enabled = int(np.count_nonzero(enabled_mask))
+        n_close = int(np.count_nonzero(close_match_mask))
+        n_fit = int(np.count_nonzero(fit_mask))
+        close_min, close_median, close_max = self._distance_summary(nearest_distances)
+        logger.info(
+            "RADECInRShiftA fit stats: n_obj=%d n_enabled=%d n_close=%d n_fit=%d "
+            "nearest_mm[min/med/max]=%.3f/%.3f/%.3f enabled_camera_ids=%s",
+            n_obj,
+            n_enabled,
+            n_close,
+            n_fit,
+            close_min,
+            close_median,
+            close_max,
+            enabled_camera_ids,
+        )
+
         dra  = np.concatenate([match_dxra,match_dyra])
         dde  = np.concatenate([match_dxde,match_dyde])
         dinr = np.concatenate([match_dxinr,match_dyinr])
@@ -374,9 +406,29 @@ class PFS():
         erry = match_obj_ydp - match_cat_ydp
         err  = np.array([np.concatenate([errx,erry])]).transpose()
 
-        newbasis = basis[np.concatenate([fit_mask, fit_mask])]
-        newerr   = err[np.concatenate([fit_mask, fit_mask])]
-        lstsq_coeffs, residual, rank, sv = np.linalg.lstsq(newbasis, newerr, rcond = None)
+        if n_fit == 0:
+            logger.warning(
+                "RADECInRShiftA refined fit had no usable rows; falling back to the coarse RA/Dec solution. "
+                "n_obj=%d n_enabled=%d n_close=%d nearest_mm[min/med/max]=%.3f/%.3f/%.3f "
+                "coarse_ra_arcsec=%.6f coarse_dec_arcsec=%.6f enabled_camera_ids=%s",
+                n_obj,
+                n_enabled,
+                n_close,
+                close_min,
+                close_median,
+                close_max,
+                coarse_ra_coeff * d_ra * 3600.0,
+                coarse_dec_coeff * d_de * 3600.0,
+                enabled_camera_ids,
+            )
+            lstsq_coeffs = self._build_coefficients(coarse_ra_coeff, coarse_dec_coeff, fit_inr, fit_scale)
+            residual = np.empty((0, 1))
+            rank = 0
+            sv = np.empty(0)
+        else:
+            newbasis = basis[np.concatenate([fit_mask, fit_mask])]
+            newerr   = err[np.concatenate([fit_mask, fit_mask])]
+            lstsq_coeffs, residual, rank, sv = np.linalg.lstsq(newbasis, newerr, rcond = None)
 
         match_obj_xy = np.stack([match_obj_xdp,match_obj_ydp]).transpose()
         match_cat_xy = np.stack([match_cat_xdp,match_cat_ydp]).transpose()
@@ -393,8 +445,23 @@ class PFS():
         for rej_itr in range(5):
             resid_r = np.sqrt(np.sum(resid_xy**2,axis=1))
 
-            inlier_flat_mask  = np.where(np.concatenate([resid_r < rejection_threshold, resid_r < rejection_threshold], 0) & np.concatenate([enabled_mask, enabled_mask], 0))
-            inlier_mask = np.where(np.concatenate([resid_r], 0) < rejection_threshold)
+            # Keep exact-zero residuals in the inlier set; otherwise a perfect
+            # first fit can empty the refit and collapse the solution to zeros.
+            inlier_mask = resid_r <= rejection_threshold
+            inlier_flat_mask = np.concatenate([inlier_mask, inlier_mask]) & np.concatenate([enabled_mask, enabled_mask])
+
+            if not np.any(inlier_flat_mask):
+                logger.warning(
+                    "RADECInRShiftA rejection step produced no inliers; retaining the previous solution and stopping. "
+                    "iteration=%d rejection_threshold=%.6f n_obj=%d n_enabled=%d n_close=%d n_fit=%d",
+                    rej_itr,
+                    rejection_threshold,
+                    n_obj,
+                    n_enabled,
+                    n_close,
+                    n_fit,
+                )
+                break
 
             basis2 = basis[inlier_flat_mask]
             err2   = err[inlier_flat_mask]
@@ -407,7 +474,7 @@ class PFS():
                 break
 
         resid_r = np.sqrt(np.sum(resid_xy**2,axis=1))
-        vcx = np.array([resid_r<rejection_threshold]).transpose()
+        vcx = np.array([resid_r<=rejection_threshold]).transpose()
         match_result = np.block([match_obj_xy, match_cat_xy, err_xy, resid_xy, vcx, min_dist_index.reshape(-1,1)])
 
         # ── Phase 7: Unit conversion ──────────────────────────────────────────
@@ -551,13 +618,6 @@ class PFS():
         xdp2_1,ydp2_1 = pfs.PFS.fp2pfi(self, xfp2_1,yfp2_1,inr)
         xdp3_1,ydp3_1 = pfs.PFS.fp2pfi(self, xfp0_1,yfp0_1,inr+d_inr)
 
-        dxdpdra = xdp1-xdp0
-        dydpdra = ydp1-ydp0
-        dxdpdde = xdp2-xdp0
-        dydpdde = ydp2-ydp0
-        dxdpdinr= xdp3-xdp0
-        dydpdinr= ydp3-ydp0
-
         dxdpdra_0 = xdp1_0-xdp0_0
         dydpdra_0 = ydp1_0-ydp0_0
         dxdpdde_0 = xdp2_0-xdp0_0
@@ -572,9 +632,6 @@ class PFS():
         dxdpdinr_1= xdp3_1-xdp0_1
         dydpdinr_1= ydp3_1-ydp0_1
 
-        # v_a (averaged over both halves) is retained here for reference but is
-        # not returned; the caller requires the per-half arrays v_0 and v_1.
-        v_a = np.transpose(np.stack([xdp0,ydp0,dxdpdra,dydpdra,dxdpdde,dydpdde,dxdpdinr,dydpdinr]))
         v_0 = np.transpose(np.stack([xdp0_0,ydp0_0,dxdpdra_0,dydpdra_0,dxdpdde_0,dydpdde_0,dxdpdinr_0,dydpdinr_0]))
         v_1 = np.transpose(np.stack([xdp0_1,ydp0_1,dxdpdra_1,dydpdra_1,dxdpdde_1,dydpdde_1,dxdpdinr_1,dydpdinr_1]))
 

--- a/python/agActor/coordinates/Subaru_POPT2_PFS_AG.py
+++ b/python/agActor/coordinates/Subaru_POPT2_PFS_AG.py
@@ -199,7 +199,7 @@ class PFS():
         scale_offset : float or nan
             Radial scale offset [dimensionless].  ``nan`` when
             ``fit_scale`` is ``False``.
-        match_result : np.ndarray, shape (N, 10)
+        match_result : np.ndarray, shape (N, 11)
             Per-match result matrix with columns:
               0:  obj_x   — detected object x [mm]
               1:  obj_y   — detected object y [mm]
@@ -211,6 +211,8 @@ class PFS():
               7:  resid_y — post-fit residual y [mm]
               8:  is_inlier — 1.0 if the match survived outlier rejection
               9:  cat_index — index of the matched star in the catalog arrays
+              10: fit_contributor — 1.0 if this detection's camera was in
+                  enabled_camera_ids (i.e. contributed to the astrometric fit)
         """
 
         # ── Phase 1: Catalog unpacking ────────────────────────────────────────
@@ -514,7 +516,8 @@ class PFS():
 
         resid_r = np.sqrt(np.sum(resid_xy**2,axis=1))
         vcx = np.array([resid_r<=rejection_threshold]).transpose()
-        match_result = np.block([match_obj_xy, match_cat_xy, err_xy, resid_xy, vcx, min_dist_index.reshape(-1,1)])
+        fit_contributor = np.array([enabled_mask], dtype=float).transpose()
+        match_result = np.block([match_obj_xy, match_cat_xy, err_xy, resid_xy, vcx, min_dist_index.reshape(-1,1), fit_contributor])
 
         # ── Phase 7: Unit conversion ──────────────────────────────────────────
         # Multiply the dimensionless least-squares coefficients by the

--- a/python/agActor/field_acquisition.py
+++ b/python/agActor/field_acquisition.py
@@ -93,7 +93,10 @@ def acquire_field(
         The visit ID to retrieve guide stars from the pfs_config_agc table. If not
         provided, use the pfsDesign file with transformations.
     cameras : list[int] or None
-        One-indexed camera ids (1-6). If not provided, all cameras will be used.
+        One-indexed camera ids (1-6) whose detections are allowed to
+        contribute to the astrometric fit.  Detections from all cameras
+        are still fetched; only the fit is restricted.  If not provided,
+        all cameras contribute to the fit.
     obswl : float, optional
         Observation wavelength in nm, defaults to 0.62.
     altazimuth : bool, optional
@@ -155,7 +158,7 @@ def acquire_field(
     else:
         filter_flags = filter_flags & ~SourceDetectionFlag.BAD_SHAPE
 
-    detected_objects = get_detected_objects(frame_id, filter_flags=filter_flags, cameras=cameras)
+    detected_objects = get_detected_objects(frame_id, filter_flags=filter_flags)
     logger.info(f"Detected objects: {len(detected_objects)}")
 
     parse_kwargs(kwargs)
@@ -199,6 +202,7 @@ def acquire_field(
         m2_pos3=m2_pos3,
         obswl=obswl,
         altazimuth=altazimuth,
+        enabled_camera_ids=cameras,
         **_kwargs,
     )
 
@@ -220,6 +224,7 @@ def get_guide_offsets(
     max_size: float = 1.0e12,
     min_size: float = -1.0e0,
     max_residual: float = 0.5,
+    enabled_camera_ids: list[int] | None = None,
     **kwargs: Dict[str, Any],
 ) -> GuideOffsets:
     """Calculate guide offsets for the detected objects using the guide objects from the catalog.
@@ -258,6 +263,10 @@ def get_guide_offsets(
         Minimum size for source filtering, by default -1.0e0.
     max_residual : float, optional
         Maximum residual for source filtering, by default 0.5.
+    enabled_camera_ids : list[int] or None, optional
+        One-indexed camera IDs whose detections are allowed to contribute
+        to the astrometric fit.  Detections from other cameras are still
+        included in the returned match results.  ``None`` uses all cameras.
     **kwargs : dict, optional
         Additional keyword arguments to pass to the field acquisition and focusing calculation.
 
@@ -349,6 +358,7 @@ def get_guide_offsets(
         max_size=max_size,
         min_size=min_size,
         max_residual=max_residual,
+        enabled_camera_ids=enabled_camera_ids,
     )
     ra_offset *= 3600
     dec_offset *= 3600

--- a/python/agActor/field_acquisition.py
+++ b/python/agActor/field_acquisition.py
@@ -407,7 +407,7 @@ def get_guide_offsets(
             "resid_y",
             "matched",
             "guide_object_id",
-            "fit_contributor",
+            "camera_enabled",
         ),
     )
     match_results_df.index = detected_objects[valid_detections].index
@@ -452,7 +452,7 @@ def get_guide_offsets(
             "guide_object_y_pix",
             "agc_camera_id",
             "matched",
-            "fit_contributor",
+            "camera_enabled",
         ]
     ]
 

--- a/python/agActor/field_acquisition.py
+++ b/python/agActor/field_acquisition.py
@@ -75,6 +75,7 @@ def acquire_field(
     design_id: int,
     frame_id: int,
     visit0: int | None = None,
+    cameras: list[int] | None = None,
     obswl: float = 0.62,
     altazimuth: bool = True,
     is_guide: bool = False,
@@ -91,6 +92,8 @@ def acquire_field(
     visit0 : int or None
         The visit ID to retrieve guide stars from the pfs_config_agc table. If not
         provided, use the pfsDesign file with transformations.
+    cameras : list[int] or None
+        One-indexed camera ids (1-6). If not provided, all cameras will be used.
     obswl : float, optional
         Observation wavelength in nm, defaults to 0.62.
     altazimuth : bool, optional
@@ -111,6 +114,8 @@ def acquire_field(
             Secondary mirror position in mm
         - sequence_id : int
             Sequence ID for querying telescope status
+        - enabledCameras : list[int]
+            One-indexed enabled camera ids (1-6).
 
     Returns
     -------
@@ -149,7 +154,8 @@ def acquire_field(
         filter_flags = filter_flags | SourceDetectionFlag.BAD_SHAPE
     else:
         filter_flags = filter_flags & ~SourceDetectionFlag.BAD_SHAPE
-    detected_objects = get_detected_objects(frame_id, filter_flags=filter_flags)
+
+    detected_objects = get_detected_objects(frame_id, filter_flags=filter_flags, cameras=cameras)
     logger.info(f"Detected objects: {len(detected_objects)}")
 
     parse_kwargs(kwargs)
@@ -178,10 +184,7 @@ def acquire_field(
         inr += kwargs.get("dinr") / 3600
         logger.info(f"inr modified by dinr: {inr=}")
 
-    logger.info(f"Final values for calculating offsets: {ra=},{dec=},{inst_pa=},{inr=}")
-
-
-    logger.info(f"Calling calculate_guide_offsets with {adc=}")
+    logger.info(f"Final values for calculating offsets: {ra=},{dec=},{inst_pa=},{inr=},{adc=}")
 
     _kwargs = filter_kwargs(kwargs)
 

--- a/python/agActor/field_acquisition.py
+++ b/python/agActor/field_acquisition.py
@@ -407,6 +407,7 @@ def get_guide_offsets(
             "resid_y",
             "matched",
             "guide_object_id",
+            "fit_contributor",
         ),
     )
     match_results_df.index = detected_objects[valid_detections].index
@@ -451,6 +452,7 @@ def get_guide_offsets(
             "guide_object_y_pix",
             "agc_camera_id",
             "matched",
+            "fit_contributor",
         ]
     ]
 

--- a/python/agActor/utils/data.py
+++ b/python/agActor/utils/data.py
@@ -793,8 +793,9 @@ def write_agc_match(
             logger.info(
                 "write_agc_match: camera_enabled (pending schema change — "
                 "will become agc_match.camera_enabled): "
-                "frame_id=%d n_enabled=%d n_disabled=%d values=%s",
+                "frame_id=%d n_total=%d n_enabled=%d n_disabled=%d values=%s",
                 frame_id,
+                len(enabled),
                 int(enabled.sum()),
                 int((~enabled).sum()),
                 identified_objects["camera_enabled"].tolist(),

--- a/python/agActor/utils/data.py
+++ b/python/agActor/utils/data.py
@@ -9,15 +9,12 @@ import numpy as np
 import pandas as pd
 from astropy import units as u
 from astropy.table import Table
-
 from numpy.typing import NDArray
 from pfs.utils.coordinates import updateTargetPosition
 from pfs.utils.coordinates.CoordTransp import ag_pfimm_to_pixel
-
 from pfs.utils.database.db import DB
-from pfs.utils.database.opdb import OpDB
 from pfs.utils.database.gaia import GaiaDB
-
+from pfs.utils.database.opdb import OpDB
 from pfs.utils.datamodel.ag import AutoGuiderStarMask, SourceDetectionFlag
 
 logger = logging.getLogger(__name__)
@@ -646,7 +643,9 @@ def tweak_target_position(
 
 
 def get_detected_objects(
-    frame_id: int, filter_flags: int | None = BAD_DETECTION_FLAGS
+    frame_id: int,
+    filter_flags: int | None = BAD_DETECTION_FLAGS,
+    cameras: list[int] | None = None
 ) -> pd.DataFrame:
     """Get the detected objects from opdb.agc_data.
 
@@ -656,6 +655,9 @@ def get_detected_objects(
             The frame id of the frame.
         filter_flags: SourceDetectionFlag | int
             Flag to filter out detected objects. Defaults to BAD_DETECTION_FLAGS.
+        cameras: list[int] | None
+            One-indexed camera ids to include, e.g. [1, 2, 6]. If None, includes all
+            cameras.
 
     Returns:
     --------
@@ -667,8 +669,16 @@ def get_detected_objects(
     RuntimeError:
         If no detected objects are found.
     """
-    logger.info("Getting detected objects from opdb.agc_data")
-    detected_objects = query_agc_data(frame_id)
+    # query_agc_data wants a list of zero-based camera ids. `1` -> `0`
+    if cameras is not None:
+        try:
+            cameras = [int(camera_id) - 1 for camera_id in cameras]
+        except Exception as e:
+            logger.warning(f"Failed to parse cameras list {cameras}: {e} using all cameras")
+            cameras = None
+
+    logger.info(f"Getting detected objects from opdb.agc_data with {cameras=}")
+    detected_objects = query_agc_data(frame_id, cameras=cameras)
     logger.debug(f"Detected objects: {len(detected_objects)}")
 
     if filter_flags:
@@ -950,7 +960,29 @@ def query_db(
     return result
 
 
-def query_agc_data(agc_exposure_id: int, as_dataframe: bool = True, **kwargs):
+def query_agc_data(agc_exposure_id: int, as_dataframe: bool = True, cameras: list | None = None, **kwargs):
+    """Query AGC detected sources for one exposure.
+
+    Parameters
+    ----------
+    agc_exposure_id : int
+        AGC exposure ID to query from ``agc_data``.
+    as_dataframe : bool, optional
+        If True, return a pandas DataFrame. If False, return a NumPy array.
+    cameras : list | None, optional
+        List of AG camera IDs to include. Camera IDs are **zero-based**
+        (valid values are typically ``[0, 1, 2, 3, 4, 5]``). If None,
+        all zero-based AG cameras are queried.
+    **kwargs
+        Additional keyword arguments forwarded to ``query_db``.
+
+    Returns
+    -------
+    pd.DataFrame | np.ndarray
+        Rows from ``agc_data`` filtered by exposure ID and camera IDs.
+    """
+    cameras = cameras or [0, 1, 2, 3, 4, 5]
+
     sql = """
 SELECT agc_camera_id,
  spot_id,
@@ -966,10 +998,13 @@ SELECT agc_camera_id,
  background,
  COALESCE(flags, CAST(centroid_x_pix >= 511.5 + 24 AS INTEGER)) AS flags
 FROM agc_data
-WHERE agc_exposure_id = :agc_exposure_id
+WHERE 
+    agc_exposure_id = :agc_exposure_id 
+  AND
+    agc_camera_id = ANY(:cameras)
 ORDER BY agc_camera_id, spot_id
 """
-    params = {"agc_exposure_id": agc_exposure_id}
+    params = {"agc_exposure_id": agc_exposure_id, "cameras": cameras}
     return query_db(sql, params, as_dataframe=as_dataframe, **kwargs)
 
 

--- a/python/agActor/utils/data.py
+++ b/python/agActor/utils/data.py
@@ -948,7 +948,7 @@ def query_db(
     return result
 
 
-def query_agc_data(agc_exposure_id: int, as_dataframe: bool = True, cameras: list | None = None, **kwargs):
+def query_agc_data(agc_exposure_id: int, as_dataframe: bool = True, **kwargs):
     """Query AGC detected sources for one exposure.
 
     Parameters
@@ -957,20 +957,14 @@ def query_agc_data(agc_exposure_id: int, as_dataframe: bool = True, cameras: lis
         AGC exposure ID to query from ``agc_data``.
     as_dataframe : bool, optional
         If True, return a pandas DataFrame. If False, return a NumPy array.
-    cameras : list | None, optional
-        List of AG camera IDs to include. Camera IDs are **zero-based**
-        (valid values are typically ``[0, 1, 2, 3, 4, 5]``). If None,
-        all zero-based AG cameras are queried.
     **kwargs
         Additional keyword arguments forwarded to ``query_db``.
 
     Returns
     -------
     pd.DataFrame | np.ndarray
-        Rows from ``agc_data`` filtered by exposure ID and camera IDs.
+        Rows from ``agc_data`` for the given exposure ID.
     """
-    cameras = cameras or [0, 1, 2, 3, 4, 5]
-
     sql = """
 SELECT agc_camera_id,
  spot_id,
@@ -986,13 +980,10 @@ SELECT agc_camera_id,
  background,
  COALESCE(flags, CAST(centroid_x_pix >= 511.5 + 24 AS INTEGER)) AS flags
 FROM agc_data
-WHERE 
-    agc_exposure_id = :agc_exposure_id 
-  AND
-    agc_camera_id = ANY(:cameras)
+WHERE agc_exposure_id = :agc_exposure_id
 ORDER BY agc_camera_id, spot_id
 """
-    params = {"agc_exposure_id": agc_exposure_id, "cameras": cameras}
+    params = {"agc_exposure_id": agc_exposure_id}
     return query_db(sql, params, as_dataframe=as_dataframe, **kwargs)
 
 

--- a/python/agActor/utils/data.py
+++ b/python/agActor/utils/data.py
@@ -645,7 +645,6 @@ def tweak_target_position(
 def get_detected_objects(
     frame_id: int,
     filter_flags: int | None = BAD_DETECTION_FLAGS,
-    cameras: list[int] | None = None
 ) -> pd.DataFrame:
     """Get the detected objects from opdb.agc_data.
 
@@ -655,9 +654,6 @@ def get_detected_objects(
             The frame id of the frame.
         filter_flags: SourceDetectionFlag | int
             Flag to filter out detected objects. Defaults to BAD_DETECTION_FLAGS.
-        cameras: list[int] | None
-            One-indexed camera ids to include, e.g. [1, 2, 6]. If None, includes all
-            cameras.
 
     Returns:
     --------
@@ -669,16 +665,8 @@ def get_detected_objects(
     RuntimeError:
         If no detected objects are found.
     """
-    # query_agc_data wants a list of zero-based camera ids. `1` -> `0`
-    if cameras is not None:
-        try:
-            cameras = [int(camera_id) - 1 for camera_id in cameras]
-        except Exception as e:
-            logger.warning(f"Failed to parse cameras list {cameras}: {e} using all cameras")
-            cameras = None
-
-    logger.info(f"Getting detected objects from opdb.agc_data with {cameras=}")
-    detected_objects = query_agc_data(frame_id, cameras=cameras)
+    logger.info(f"Getting detected objects from opdb.agc_data for {frame_id=}")
+    detected_objects = query_agc_data(frame_id)
     logger.debug(f"Detected objects: {len(detected_objects)}")
 
     if filter_flags:

--- a/python/agActor/utils/data.py
+++ b/python/agActor/utils/data.py
@@ -786,6 +786,25 @@ def write_agc_match(
     """
     db = db or OpDB()
     try:
+        # Log the camera_enabled column that will be written to agc_match once the
+        # schema gains the column.  Until then this is the only record of the value.
+        if "camera_enabled" in identified_objects.columns:
+            enabled = identified_objects["camera_enabled"].astype(bool)
+            logger.info(
+                "write_agc_match: camera_enabled (pending schema change — "
+                "will become agc_match.camera_enabled): "
+                "frame_id=%d n_enabled=%d n_disabled=%d values=%s",
+                frame_id,
+                int(enabled.sum()),
+                int((~enabled).sum()),
+                identified_objects["camera_enabled"].tolist(),
+            )
+        else:
+            logger.warning(
+                "write_agc_match: camera_enabled column missing from identified_objects; "
+                "cannot log pending camera_enabled values"
+            )
+
         rows_to_insert = []
         for idx, match in identified_objects.iterrows():
             detected_idx = int(match.detected_object_id)

--- a/python/agActor/utils/focus.py
+++ b/python/agActor/utils/focus.py
@@ -59,9 +59,12 @@ def focus(
             # agc_camera_id in the DataFrame is zero-based; enabledCameras is one-based.
             enabled_set = {int(camera_id) - 1 for camera_id in enabledCameras}
             detected_objects = detected_objects[detected_objects["agc_camera_id"].isin(enabled_set)]
-        except Exception as e:
+        except (TypeError, ValueError) as e:
+            # Only catch conversion errors from malformed enabledCameras values.
+            # Other errors (e.g. missing column) should propagate so they are not masked.
             logger.warning(
-                f"Failed to filter detected objects with enabled cameras {enabledCameras}: {e}; using all cameras"
+                f"Failed to filter detected objects with enabled cameras {enabledCameras}: {e}; using all cameras",
+                exc_info=True,
             )
 
     logger.info(f"In focus with {max_ellipticity=}, {max_size=}, {min_size=}")

--- a/python/agActor/utils/focus.py
+++ b/python/agActor/utils/focus.py
@@ -15,6 +15,7 @@ def focus(
     *,
     frame_id: int | None = None,
     detected_objects: pd.DataFrame | None = None,
+    enabledCameras: list[int] | None = None,
     max_ellipticity: float = 2.0e0,
     max_size: float = 1.0e12,
     min_size: float = -1.0e0,
@@ -28,6 +29,8 @@ def focus(
         Frame ID to use for retrieving detected objects. Either frame_id or detected_objects must be provided.
     detected_objects : pd.DataFrame | None
         DataFrame of detected objects. Either frame_id or detected_objects must be provided.
+    enabledCameras : list[int] | None
+        One-indexed AG camera IDs to use. If None, all cameras are used.
     max_ellipticity : float
         Maximum ellipticity for source filtering, by default 2.0e0
     max_size : float
@@ -49,7 +52,26 @@ def focus(
 
     if frame_id is not None and detected_objects is None:
         logger.info(f"In focus, getting detected objects for {frame_id=}")
-        detected_objects = query_agc_data(frame_id)
+        cameras = None
+        if enabledCameras is not None:
+            try:
+                cameras = [int(camera_id) - 1 for camera_id in enabledCameras]
+            except Exception as e:
+                logger.warning(
+                    f"Failed to parse enabled camera list {enabledCameras}: {e}; using all cameras"
+                )
+                cameras = None
+        detected_objects = query_agc_data(frame_id, cameras=cameras)
+
+    if frame_id is None and detected_objects is not None:
+        if enabledCameras is not None:
+            try:
+                enabled_set = {int(camera_id) - 1 for camera_id in enabledCameras}
+                detected_objects = detected_objects[detected_objects["agc_camera_id"].isin(enabled_set)]
+            except Exception as e:
+                logger.warning(
+                    f"Failed to filter detected objects with enabled cameras {enabledCameras}: {e}; using all cameras"
+                )
 
     logger.info(f"In focus with {max_ellipticity=}, {max_size=}, {min_size=}")
 

--- a/python/agActor/utils/focus.py
+++ b/python/agActor/utils/focus.py
@@ -52,26 +52,17 @@ def focus(
 
     if frame_id is not None and detected_objects is None:
         logger.info(f"In focus, getting detected objects for {frame_id=}")
-        cameras = None
-        if enabledCameras is not None:
-            try:
-                cameras = [int(camera_id) - 1 for camera_id in enabledCameras]
-            except Exception as e:
-                logger.warning(
-                    f"Failed to parse enabled camera list {enabledCameras}: {e}; using all cameras"
-                )
-                cameras = None
-        detected_objects = query_agc_data(frame_id, cameras=cameras)
+        detected_objects = query_agc_data(frame_id)
 
-    if frame_id is None and detected_objects is not None:
-        if enabledCameras is not None:
-            try:
-                enabled_set = {int(camera_id) - 1 for camera_id in enabledCameras}
-                detected_objects = detected_objects[detected_objects["agc_camera_id"].isin(enabled_set)]
-            except Exception as e:
-                logger.warning(
-                    f"Failed to filter detected objects with enabled cameras {enabledCameras}: {e}; using all cameras"
-                )
+    if enabledCameras is not None:
+        try:
+            # agc_camera_id in the DataFrame is zero-based; enabledCameras is one-based.
+            enabled_set = {int(camera_id) - 1 for camera_id in enabledCameras}
+            detected_objects = detected_objects[detected_objects["agc_camera_id"].isin(enabled_set)]
+        except Exception as e:
+            logger.warning(
+                f"Failed to filter detected objects with enabled cameras {enabledCameras}: {e}; using all cameras"
+            )
 
     logger.info(f"In focus with {max_ellipticity=}, {max_size=}, {min_size=}")
 


### PR DESCRIPTION
This gets a list of `enabled` cameras from `pfs_instdata` (https://github.com/Subaru-PFS/pfs_instdata/pull/51/changes) and uses that to filter the detected data so that it is not used in any offset or focus caluclations.

The camera will still expose and populate `agc_data`. 

⚠️ Note that the branch is incorrectly named `2917` instead of `2919`.